### PR TITLE
Add build_kernel.sh script and tests

### DIFF
--- a/scripts/build_kernel.sh
+++ b/scripts/build_kernel.sh
@@ -1,0 +1,530 @@
+#!/usr/bin/env bash
+#
+# build_kernel.sh - Download, patch, build and install a Linux kernel on the
+# current machine, then (optionally) reboot into it. Targets throw-away EC2
+# repro/benchmark instances running Amazon Linux 2023 or Ubuntu.
+#
+# It clones a kernel tree, checks out a branch/tag, seeds .config from the
+# running kernel, tweaks it for EC2/ENA (and blanks the distro signing keys so
+# the build does not need vendor certs), applies any number of patches, builds
+# the kernel + modules + perf, installs them, wires up the bootloader, and
+# prompts to reboot.
+#
+# Distro handling is auto-detected:
+#   * AL2023 (dnf)   -> dracut for initramfs, grubby for the boot entry/default.
+#   * Ubuntu (apt)   -> `make install` hooks build the initramfs + update grub;
+#                       we run update-grub as a belt-and-braces step.
+#
+# Examples
+# --------
+#   # linux-next @ next-20260707, two fixes, auto-reboot, all defaults:
+#   scripts/build_kernel.sh -p fix1.patch -p fix2.patch --yes
+#
+#   # Amazon Linux kernel tag, custom source dir, do not reboot:
+#   scripts/build_kernel.sh \
+#     --repo https://github.com/amazonlinux/linux.git \
+#     --branch kernel6.12-6.12.68-92.122.amzn2023 \
+#     --dir ~/amzn-linux -p my-fix.patch --no-reboot
+#
+#   # Remote execution on EC2 instance with custom key:
+#   SSH_OPTIONS="-i ~/.ssh/my-key.pem" scripts/build_kernel.sh \
+#     -c ec2-user@192.168.1.100 -p fix.patch --yes
+#
+# Options
+# -------
+#   -p, --patch FILE     Patch to apply (repeatable, applied in the given order,
+#                        via `git apply`). Paths are resolved before we cd into
+#                        the source tree, so relative paths work.
+#   -c, --connect USER@HOST  Execute on a remote system via SSH. Uploads patches
+#                        and the script itself, runs remotely, streams output to
+#                        local terminal, and saves log to ~/build_kernel_<timestamp>.log
+#                        on the remote. Use SSH_OPTIONS env var for custom SSH flags.
+#   -r, --repo URL       Kernel git repo to clone
+#                        (default: git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git)
+#   -b, --branch REF     Branch/tag/commit to check out (default: next-20260707)
+#   -d, --dir PATH       Kernel source directory (default: ~/linux-next).
+#                        Reused if it already exists (fetch + checkout).
+#   -j, --jobs N         Parallel build jobs (default: nproc)
+#   -l, --localversion S LOCALVERSION suffix (default: -<short-commit-id>)
+#       --config-only    Configure only; stop before compiling (dry-ish run)
+#       --skip-deps      Do not install build dependencies
+#       --no-perf        Do not build/install perf from the tree
+#   -y, --yes            Reboot at the end without prompting
+#       --no-reboot      Never reboot; just print the instruction
+#   -h, --help           Show this help and exit
+#
+# Environment (advanced)
+# ----------------------
+#   SSH_OPTIONS          SSH options for remote execution (e.g., "-i /path/to/key.pem")
+#   BOOT_DIR             Boot directory to read the running config from and to
+#                        install the image/initramfs into (default: /boot).
+#                        Useful for alt-boot/chroot builds and for testing.
+#   PERF_DEST            Destination path for the built perf binary
+#                        (default: /usr/local/bin/perf).
+#
+set -euo pipefail
+
+# --------------------------------------------------------------------------
+# Helpers (same style as aws_create_instance.sh)
+# --------------------------------------------------------------------------
+err()  { printf '\033[31m[ERROR]\033[0m %s\n' "$*" >&2; }
+info() { printf '\033[36m[INFO ]\033[0m %s\n'  "$*" >&2; }
+warn() { printf '\033[33m[WARN ]\033[0m %s\n'  "$*" >&2; }
+step() { printf '\033[32m[STEP ]\033[0m %s\n'  "$*" >&2; }
+die()  { err "$*"; exit 1; }
+
+usage() { sed -n '2,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//; s/^#$//; /^set -euo/d'; }
+
+# --------------------------------------------------------------------------
+# Defaults
+# --------------------------------------------------------------------------
+KERNEL_REPO="git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git"
+KERNEL_BRANCH="next-20260707"
+KERNEL_DIR="${HOME}/linux-next"
+JOBS="$(nproc)"
+LOCALVERSION=""            # defaults to -<commit> once we know the commit id
+CONFIG_ONLY=false
+SKIP_DEPS=false
+BUILD_PERF=true
+REBOOT_MODE="prompt"       # prompt | yes | never
+BOOT_DIR="${BOOT_DIR:-/boot}"   # overridable for chroot/alt-boot builds + tests
+PERF_DEST="${PERF_DEST:-/usr/local/bin/perf}"   # where the built perf lands
+REMOTE_HOST=""             # set via -c/--connect for remote execution
+SSH_OPTIONS="${SSH_OPTIONS:-}"  # custom SSH flags (e.g., "-i key.pem")
+PATCHES=()
+
+# --------------------------------------------------------------------------
+# Parse arguments
+# --------------------------------------------------------------------------
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -p|--patch)        PATCHES+=("$2"); shift 2 ;;
+        -c|--connect)      REMOTE_HOST="$2"; shift 2 ;;
+        -r|--repo)         KERNEL_REPO="$2"; shift 2 ;;
+        -b|--branch)       KERNEL_BRANCH="$2"; shift 2 ;;
+        -d|--dir)          KERNEL_DIR="$2"; shift 2 ;;
+        -j|--jobs)         JOBS="$2"; shift 2 ;;
+        -l|--localversion) LOCALVERSION="$2"; shift 2 ;;
+        --config-only)     CONFIG_ONLY=true; shift ;;
+        --skip-deps)       SKIP_DEPS=true; shift ;;
+        --no-perf)         BUILD_PERF=false; shift ;;
+        -y|--yes)          REBOOT_MODE="yes"; shift ;;
+        --no-reboot)       REBOOT_MODE="never"; shift ;;
+        -h|--help)         usage; exit 0 ;;
+        *)                 die "Unknown argument: $1 (use --help)" ;;
+    esac
+done
+
+# Resolve patch paths to absolute now, before we cd into the source tree.
+PATCHES_ABS=()
+for p in "${PATCHES[@]:-}"; do
+    [ -z "${p}" ] && continue
+    [ -f "${p}" ] || die "Patch file not found: ${p}"
+    PATCHES_ABS+=("$(readlink -f "${p}")")
+done
+
+# --------------------------------------------------------------------------
+# Remote execution mode
+# --------------------------------------------------------------------------
+if [ -n "${REMOTE_HOST}" ]; then
+    info "Remote execution mode: uploading patches and script to ${REMOTE_HOST}"
+
+    # Build SSH command with optional custom flags
+    SSH_CMD="ssh ${SSH_OPTIONS}"
+    SCP_CMD="scp ${SSH_OPTIONS}"
+
+    # Create remote patch directory
+    REMOTE_PATCH_DIR="/tmp/build_kernel_patches"
+    ${SSH_CMD} "${REMOTE_HOST}" "mkdir -p ${REMOTE_PATCH_DIR}" || die "Failed to create remote patch directory"
+
+    # Upload patches if any
+    REMOTE_PATCHES_ABS=()
+    if [ "${#PATCHES_ABS[@]}" -gt 0 ]; then
+        for patch in "${PATCHES_ABS[@]}"; do
+            patch_name="$(basename "${patch}")"
+            info "Uploading patch: ${patch_name}"
+            ${SCP_CMD} "${patch}" "${REMOTE_HOST}:${REMOTE_PATCH_DIR}/${patch_name}" || die "Failed to upload patch: ${patch}"
+            REMOTE_PATCHES_ABS+=("${REMOTE_PATCH_DIR}/${patch_name}")
+        done
+    else
+        info "No patches to upload"
+    fi
+
+    # Upload this script to remote home
+    REMOTE_SCRIPT="/tmp/build_kernel_remote_$$.sh"
+    info "Uploading script to ${REMOTE_HOST}:${REMOTE_SCRIPT}"
+    ${SCP_CMD} "$0" "${REMOTE_HOST}:${REMOTE_SCRIPT}" || die "Failed to upload script"
+    ${SSH_CMD} "${REMOTE_HOST}" "chmod +x ${REMOTE_SCRIPT}" || die "Failed to chmod script"
+
+    # Build remote command (all flags except -c, with remote patch paths)
+    REMOTE_CMD="${REMOTE_SCRIPT}"
+    if [ "${#REMOTE_PATCHES_ABS[@]}" -gt 0 ]; then
+        for patch in "${REMOTE_PATCHES_ABS[@]}"; do
+            REMOTE_CMD+=" -p ${patch}"
+        done
+    fi
+    [ -n "${KERNEL_REPO}" ] && REMOTE_CMD+=" -r ${KERNEL_REPO}"
+    [ -n "${KERNEL_BRANCH}" ] && REMOTE_CMD+=" -b ${KERNEL_BRANCH}"
+    [ "${KERNEL_DIR}" != "${HOME}/linux-next" ] && REMOTE_CMD+=" -d ${KERNEL_DIR}"
+    [ "${JOBS}" != "$(nproc)" ] && REMOTE_CMD+=" -j ${JOBS}"
+    [ -n "${LOCALVERSION}" ] && REMOTE_CMD+=" -l ${LOCALVERSION}"
+    [ "${CONFIG_ONLY}" = "true" ] && REMOTE_CMD+=" --config-only"
+    [ "${SKIP_DEPS}" = "true" ] && REMOTE_CMD+=" --skip-deps"
+    [ "${BUILD_PERF}" = "false" ] && REMOTE_CMD+=" --no-perf"
+    case "${REBOOT_MODE}" in
+        yes)   REMOTE_CMD+=" --yes" ;;
+        never) REMOTE_CMD+=" --no-reboot" ;;
+    esac
+
+    # Generate timestamp for log file
+    LOG_TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+    REMOTE_LOG="\${HOME}/build_kernel_${LOG_TIMESTAMP}.log"
+
+    # Execute remotely: stream to terminal + save log
+    info "Executing remotely (log saved to ${REMOTE_LOG}):"
+    info "Command: ${REMOTE_CMD}"
+    # pipefail is essential here: without it the pipe's status is tee's (always
+    # 0), so a remote build failure would be masked and we'd wrongly proceed.
+    ${SSH_CMD} "${REMOTE_HOST}" "bash -c 'set -o pipefail; ${REMOTE_CMD} 2>&1 | tee ${REMOTE_LOG}'" || die "Remote execution failed"
+
+    info "Build complete. Log saved on remote: ${REMOTE_LOG}"
+
+    # If --yes was specified, wait for reboot and verify new kernel
+    if [ "${REBOOT_MODE}" = "yes" ]; then
+        info "Waiting for remote host to reboot (this may take 1-2 minutes)..."
+        sleep 10  # Give the reboot command time to execute
+
+        # Wait for SSH to become unavailable (host is rebooting)
+        WAIT_DOWN=0
+        while ${SSH_CMD} -o ConnectTimeout=2 "${REMOTE_HOST}" "true" >/dev/null 2>&1; do
+            sleep 2
+            WAIT_DOWN=$((WAIT_DOWN + 1))
+            if [ "$WAIT_DOWN" -gt 30 ]; then
+                warn "Remote host did not go down after 60s. It may have already rebooted."
+                break
+            fi
+        done
+
+        # Wait for SSH to become available again (host is back up)
+        info "Waiting for remote host to come back online..."
+        WAIT_UP=0
+        while ! ${SSH_CMD} -o ConnectTimeout=5 "${REMOTE_HOST}" "true" >/dev/null 2>&1; do
+            sleep 5
+            WAIT_UP=$((WAIT_UP + 1))
+            if [ "$WAIT_UP" -gt 60 ]; then
+                die "Remote host did not come back online after 5 minutes"
+            fi
+            printf "." >&2
+        done
+        echo "" >&2
+
+        # Fetch and display new kernel info
+        info "Remote host is back online. Fetching kernel information..."
+
+        NEW_KERNEL=$(${SSH_CMD} "${REMOTE_HOST}" "uname -r" 2>/dev/null || echo "unknown")
+        KERNEL_VERSION=$(${SSH_CMD} "${REMOTE_HOST}" "uname -v" 2>/dev/null || echo "")
+
+        # Try to extract build info from the remote log
+        BUILD_INFO=$(${SSH_CMD} "${REMOTE_HOST}" "grep -E 'Commit:|Kernel version:|Image path:' ${REMOTE_LOG} 2>/dev/null" || true)
+
+        cat >&2 <<REBOOT_SUMMARY
+
+===================== Remote Kernel Verification =====================
+  Remote host    : ${REMOTE_HOST}
+  New kernel     : ${NEW_KERNEL}
+  Build details  : ${REMOTE_LOG}
+
+${BUILD_INFO}
+======================================================================
+
+REBOOT_SUMMARY
+    else
+        info "Remote build complete (reboot skipped)."
+    fi
+
+    exit 0
+fi
+
+# --------------------------------------------------------------------------
+# Detect the package manager / distro family.
+# --------------------------------------------------------------------------
+if command -v dnf >/dev/null 2>&1; then
+    PKG="dnf"
+elif command -v apt-get >/dev/null 2>&1; then
+    PKG="apt"
+else
+    die "No supported package manager found (need dnf on AL2023 or apt on Ubuntu)"
+fi
+info "Package manager: ${PKG}"
+
+# --------------------------------------------------------------------------
+# 1. Requirements
+# --------------------------------------------------------------------------
+install_deps() {
+    if [ "${SKIP_DEPS}" = "true" ]; then
+        info "Skipping dependency install (--skip-deps)"
+        return 0
+    fi
+    step "1. Installing build dependencies"
+    if [ "${PKG}" = "dnf" ]; then
+        sudo dnf install -y \
+            libdwarf-devel binutils-devel libcap-devel numactl-libs \
+            libunwind-devel zlib-devel xz-devel libaio-devel \
+            libtraceevent-devel libpfm-devel slang-devel systemtap-sdt-devel \
+            perl-ExtUtils-Embed python-devel git libbabeltrace-devel \
+            libzstd-devel libzstd gcc-c++ flex bison openssl-devel \
+            elfutils-libelf-devel elfutils-devel numactl-devel \
+            capstone-devel llvm-devel rust cargo make bc kmod cpio dracut grubby
+    else
+        sudo apt-get update -y
+        # Ubuntu equivalents of the AL2023 list + core kernel-build deps.
+        sudo apt-get install -y \
+            build-essential flex bison libssl-dev libelf-dev libdw-dev \
+            bc kmod cpio rsync git make g++ \
+            libdwarf-dev binutils-dev libcap-dev libnuma-dev \
+            libunwind-dev zlib1g-dev liblzma-dev libaio-dev \
+            libtraceevent-dev libpfm4-dev libslang2-dev systemtap-sdt-dev \
+            libperl-dev python3-dev libbabeltrace-dev libzstd-dev \
+            libcapstone-dev llvm-dev clang rustc cargo \
+            libncurses-dev initramfs-tools
+    fi
+
+    # dnf/apt can report success even when a package failed to land (e.g. a
+    # dnf cache miss prints "[Errno 2] No such file..." yet still exits 0).
+    # Verify the tools we actually depend on are on PATH before continuing.
+    local missing=()
+    for tool in git make gcc flex bison bc cpio; do
+        command -v "${tool}" >/dev/null 2>&1 || missing+=("${tool}")
+    done
+    [ "${BUILD_PERF}" = "true" ] && { command -v cargo >/dev/null 2>&1 || missing+=("cargo"); }
+    [ "${#missing[@]}" -eq 0 ] \
+        || die "Build dependencies missing after install: ${missing[*]} (dependency install may have partially failed)"
+}
+install_deps
+
+# --------------------------------------------------------------------------
+# 2. Kernel code
+# --------------------------------------------------------------------------
+step "2. Fetching kernel source into ${KERNEL_DIR}"
+if [ -d "${KERNEL_DIR}/.git" ]; then
+    info "Reusing existing tree; fetching latest refs"
+    git -C "${KERNEL_DIR}" fetch --tags --prune origin
+elif [ -e "${KERNEL_DIR}" ]; then
+    die "${KERNEL_DIR} exists but is not a git repo; move it aside or pass --dir"
+else
+    info "Cloning ${KERNEL_REPO}"
+    git clone "${KERNEL_REPO}" "${KERNEL_DIR}"
+fi
+
+cd "${KERNEL_DIR}"
+info "Checking out ${KERNEL_BRANCH}"
+git checkout -f "${KERNEL_BRANCH}"
+
+COMMIT_ID="$(git rev-parse --short HEAD)"
+[ -n "${LOCALVERSION}" ] || LOCALVERSION="-${COMMIT_ID}"
+info "Commit: ${COMMIT_ID}  LOCALVERSION: ${LOCALVERSION}"
+
+# --------------------------------------------------------------------------
+# 3. Config (seed from the running kernel, with fallbacks)
+# --------------------------------------------------------------------------
+step "3. Seeding .config"
+RUNNING_CFG="${BOOT_DIR}/config-$(uname -r)"
+if [ -f "${RUNNING_CFG}" ]; then
+    info "Using ${RUNNING_CFG}"
+    cp "${RUNNING_CFG}" "${KERNEL_DIR}/.config"
+elif [ -f /proc/config.gz ]; then
+    info "${RUNNING_CFG} not found; extracting /proc/config.gz"
+    zcat /proc/config.gz > "${KERNEL_DIR}/.config"
+elif [ -f "${KERNEL_DIR}/.config" ]; then
+    info "${RUNNING_CFG} not found; reusing existing .config in source tree"
+else
+    # Last resort: pick the newest /boot/config-* available.
+    FALLBACK_CFG="$(ls -t "${BOOT_DIR}"/config-* 2>/dev/null | head -n1 || true)"
+    if [ -n "${FALLBACK_CFG}" ]; then
+        info "${RUNNING_CFG} not found; falling back to ${FALLBACK_CFG}"
+        cp "${FALLBACK_CFG}" "${KERNEL_DIR}/.config"
+    else
+        die "Cannot find any kernel config (tried ${RUNNING_CFG}, /proc/config.gz, ${BOOT_DIR}/config-*)"
+    fi
+fi
+
+# --------------------------------------------------------------------------
+# 4. Tweak config for EC2/ENA and drop distro signing keys
+# --------------------------------------------------------------------------
+step "4. Applying EC2/ENA + signing-key config tweaks"
+cat >> .config << 'EOF'
+CONFIG_NET_VENDOR_AMAZON=y
+CONFIG_DEBUG_INFO_BTF=n
+EOF
+
+# ENA driver: mainline lives at drivers/net/ethernet/amazon/ena (CONFIG_ENA_ETHERNET).
+# The Amazon Linux tree ALSO ships a downstream copy at drivers/amazon/net/ena,
+# and both produce ena.ko -- enabling the mainline one on top of the downstream
+# one makes `make modules_check` abort with a module-name conflict. So only force
+# the mainline driver on when the tree has no downstream ENA (e.g. upstream /
+# linux-next, where it's the only ENA and must be enabled for the box to network).
+if [ -d "drivers/amazon/net/ena" ]; then
+    info "Downstream Amazon ENA driver present; leaving CONFIG_ENA_ETHERNET as seeded (avoids ena.ko conflict)"
+else
+    printf 'CONFIG_ENA_ETHERNET=m\n' >> .config
+fi
+
+# Blank the trusted/revocation key lists so the build does not require the
+# distro's vendor certificates (Ubuntu configs point these at canonical paths).
+./scripts/config --set-str CONFIG_SYSTEM_TRUSTED_KEYS ""
+./scripts/config --set-str CONFIG_SYSTEM_REVOCATION_KEYS ""
+
+# --------------------------------------------------------------------------
+# 5. Apply patches (in order), via git apply
+# --------------------------------------------------------------------------
+if [ "${#PATCHES_ABS[@]}" -gt 0 ]; then
+    step "5. Applying ${#PATCHES_ABS[@]} patch(es)"
+    for patch in "${PATCHES_ABS[@]}"; do
+        info "Patch: ${patch}"
+        git apply --stat "${patch}"
+        git apply --check "${patch}" || die "Patch does not apply cleanly: ${patch}"
+        git apply "${patch}"
+        info "Applied: ${patch}"
+    done
+else
+    info "5. No patches to apply"
+fi
+
+# --------------------------------------------------------------------------
+# 6. Finalize config
+# --------------------------------------------------------------------------
+step "6. make olddefconfig"
+make olddefconfig
+
+if [ "${CONFIG_ONLY}" = "true" ]; then
+    info "--config-only set: configuration complete, stopping before compile."
+    info "Source tree: ${KERNEL_DIR}  (LOCALVERSION=${LOCALVERSION})"
+    exit 0
+fi
+
+# --------------------------------------------------------------------------
+# 7. Compile
+# --------------------------------------------------------------------------
+step "7. Compiling kernel (-j ${JOBS}, LOCALVERSION=${LOCALVERSION})"
+make -j "${JOBS}" LOCALVERSION="${LOCALVERSION}"
+
+# --------------------------------------------------------------------------
+# 8. Install modules and kernel
+# --------------------------------------------------------------------------
+step "8. Installing modules + kernel"
+sudo make INSTALL_MOD_STRIP=1 modules_install -j "${JOBS}" LOCALVERSION="${LOCALVERSION}"
+sudo make install -j "${JOBS}" LOCALVERSION="${LOCALVERSION}"
+
+# --------------------------------------------------------------------------
+# 8b. Save .config to /boot so subsequent builds can find it after reboot
+# --------------------------------------------------------------------------
+_installed_rel="$(make -s kernelrelease LOCALVERSION="${LOCALVERSION}" 2>/dev/null || true)"
+if [ -n "${_installed_rel}" ]; then
+    sudo cp "${KERNEL_DIR}/.config" "${BOOT_DIR}/config-${_installed_rel}"
+    info "Saved config to ${BOOT_DIR}/config-${_installed_rel}"
+fi
+
+# --------------------------------------------------------------------------
+# 9. Perf
+# --------------------------------------------------------------------------
+if [ "${BUILD_PERF}" = "true" ]; then
+    step "9. Building + installing perf"
+    make -C "${KERNEL_DIR}/tools/perf" -j "${JOBS}"
+    sudo cp "${KERNEL_DIR}/tools/perf/perf" "${PERF_DEST}"
+    info "perf installed to ${PERF_DEST}"
+else
+    info "9. Skipping perf build (--no-perf)"
+fi
+
+# --------------------------------------------------------------------------
+# 10. Determine the installed kernel release + vmlinuz path
+# --------------------------------------------------------------------------
+step "10. Resolving installed kernel version"
+# `make kernelrelease` is the authoritative release string for this tree.
+NEW_KERNEL_VER="$(make -s kernelrelease LOCALVERSION="${LOCALVERSION}" 2>/dev/null || true)"
+if [ -n "${NEW_KERNEL_VER}" ] && [ -f "${BOOT_DIR}/vmlinuz-${NEW_KERNEL_VER}" ]; then
+    NEW_KERNEL_PATH="${BOOT_DIR}/vmlinuz-${NEW_KERNEL_VER}"
+else
+    # Fallback: newest freshly-installed vmlinuz carrying our commit id.
+    NEW_KERNEL_PATH="$(ls -t "${BOOT_DIR}"/vmlinu* 2>/dev/null | grep -v '\.old$' | grep "${COMMIT_ID}" | head -n1 || true)"
+    [ -n "${NEW_KERNEL_PATH}" ] || NEW_KERNEL_PATH="$(realpath "${BOOT_DIR}/vmlinuz" 2>/dev/null || true)"
+    NEW_KERNEL_VER="$(basename "${NEW_KERNEL_PATH}" | sed 's/^vmlinuz-//')"
+fi
+[ -n "${NEW_KERNEL_PATH}" ] && [ -e "${NEW_KERNEL_PATH}" ] \
+    || die "Could not locate the installed kernel image under /boot"
+info "New kernel: ${NEW_KERNEL_VER}"
+info "Image path: ${NEW_KERNEL_PATH}"
+
+# --------------------------------------------------------------------------
+# 11-13. Bootloader wiring (distro-specific)
+# --------------------------------------------------------------------------
+if [ "${PKG}" = "dnf" ]; then
+    step "11. Generating initramfs (make install does not on AL2023)"
+    sudo dracut --force "${BOOT_DIR}/initramfs-${NEW_KERNEL_VER}.img" "${NEW_KERNEL_VER}"
+
+    step "12. Adding grub entry and making it the default"
+    # grubby --set-default fails if the entry is missing, so add it first.
+    if sudo grubby --info="${NEW_KERNEL_PATH}" >/dev/null 2>&1; then
+        info "Boot entry already exists; setting it as default"
+        sudo grubby --set-default="${NEW_KERNEL_PATH}"
+    else
+        sudo grubby --add-kernel="${NEW_KERNEL_PATH}" \
+            --initrd="${BOOT_DIR}/initramfs-${NEW_KERNEL_VER}.img" \
+            --title="Custom Kernel ${NEW_KERNEL_VER}" \
+            --copy-default --make-default
+    fi
+
+    step "13. Boot entries"
+    sudo grubby --info=ALL || true
+    sudo grubby --default-kernel || true
+else
+    # Ubuntu: `make install` runs the /etc/kernel/postinst.d hooks which build
+    # the initramfs and refresh grub; update-grub again is a safe no-op resync.
+    step "11-12. Refreshing grub (Ubuntu initramfs/grub handled by make install)"
+    if [ ! -f "${BOOT_DIR}/initrd.img-${NEW_KERNEL_VER}" ]; then
+        warn "initrd not found; generating it explicitly"
+        sudo update-initramfs -c -k "${NEW_KERNEL_VER}"
+    fi
+    sudo update-grub
+
+    step "13. Installed kernels"
+    ls -1 "${BOOT_DIR}"/vmlinuz-* 2>/dev/null || true
+    warn "Ubuntu grub boots the newest kernel by default. To pin a specific one,"
+    warn "set GRUB_DEFAULT in /etc/default/grub and re-run 'sudo update-grub'."
+fi
+
+# --------------------------------------------------------------------------
+# 14. Reboot
+# --------------------------------------------------------------------------
+cat >&2 <<SUMMARY
+
+===================== Build complete =====================
+  Source tree   : ${KERNEL_DIR}
+  Commit        : ${COMMIT_ID}
+  Kernel version: ${NEW_KERNEL_VER}
+  Image         : ${NEW_KERNEL_PATH}
+  perf          : $( [ "${BUILD_PERF}" = "true" ] && echo "${PERF_DEST}" || echo "not built" )
+==========================================================
+
+SUMMARY
+
+do_reboot() { info "Rebooting now ..."; sudo reboot; }
+
+case "${REBOOT_MODE}" in
+    yes)
+        do_reboot ;;
+    never)
+        info "Not rebooting (--no-reboot). Reboot into the new kernel with: sudo reboot" ;;
+    prompt)
+        # Default is YES; only an explicit 'n'/'no' declines.
+        if [ -t 0 ]; then
+            read -r -p "Reboot now into ${NEW_KERNEL_VER}? [Y/n] " ans || ans=""
+            case "${ans}" in
+                [Nn]|[Nn][Oo]) info "Reboot skipped. Run 'sudo reboot' when ready." ;;
+                *)             do_reboot ;;
+            esac
+        else
+            warn "Non-interactive shell; not rebooting. Run 'sudo reboot' when ready."
+        fi
+        ;;
+esac

--- a/tests/integration/build_kernel_integration.sh
+++ b/tests/integration/build_kernel_integration.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+#
+# build_kernel_integration.sh - REAL end-to-end test for the remote-execution
+# mode of scripts/build_kernel.sh (`build_kernel.sh -c USER@HOST ...`), run
+# against an EXISTING host whose SSH details you pass on the command line.
+#
+# You bring the box (any reachable AL2023/dnf or Ubuntu/apt machine -- an EC2
+# instance, a VM, bare metal, whatever); this test does NOT create or destroy
+# any cloud resources. It drives build_kernel.sh's remote mode against your host
+# in two phases -- the same "cheap pre-flight, then the expensive real thing"
+# shape as the aws_create_instance integration test:
+#
+#   Phase 1 (pre-flight, cheap-ish): build_kernel.sh -c ... --config-only
+#     Uploads the script + a patch, installs deps, clones the kernel tree,
+#     applies the patch and seeds/tweaks .config on the REMOTE, then stops
+#     before the compile. We then SSH in and assert the plumbing actually
+#     landed (patch file present in the tree, EC2/ENA tweaks in .config).
+#     No compile, no reboot -- so a broken flag/upload path is caught before
+#     paying for a full build.
+#
+#   Phase 2 (the real thing, expensive): build_kernel.sh -c ... --yes
+#     Full build + install + grub + reboot. build_kernel waits for the host to
+#     come back; we then INDEPENDENTLY SSH in and assert the box actually
+#     rebooted into the freshly built kernel: `uname -r` changed from the
+#     baseline AND carries our LOCALVERSION suffix, and perf was installed.
+#
+# Both phases run against the SAME host (phase 2 reuses phase 1's cloned tree
+# via `git fetch`).
+#
+# This is destructive to the TARGET host: Phase 2 builds+installs a kernel,
+# makes it the default boot entry, and REBOOTS the machine. It therefore refuses
+# to run without explicit confirmation (--yes or CONFIRM=yes) and prints the
+# target up front. It does not touch any host but the one you point it at.
+#
+# Usage:
+#   tests/integration/build_kernel_integration.sh --yes \
+#     -c ec2-user@1.2.3.4 -i ~/.ssh/my-key.pem
+#
+#   # Quick, cheaper smoke: pre-flight (config-only) phase only, no compile/reboot:
+#   tests/integration/build_kernel_integration.sh --yes \
+#     -c ec2-user@1.2.3.4 -i ~/.ssh/my-key.pem --config-only
+#
+# Options / env:
+#   -c, --connect USER@HOST   SSH target (required). Same form build_kernel takes.
+#   -i, --key FILE            SSH private key; prepended to the SSH options.
+#       --ssh-options "..."   Extra raw SSH options (merged with -i and the
+#                             non-interactive defaults). Also read from the
+#                             SSH_OPTIONS env var, like build_kernel itself.
+#   --config-only             Run only Phase 1 (no compile, no reboot). Cheaper.
+#   --yes | CONFIRM=yes       Required to actually run (Phase 2 reboots the box).
+#   KERNEL_REPO               Kernel git repo to build (default: the Amazon Linux
+#                             tree, so the built kernel boots on an AL2023 host).
+#   KERNEL_BRANCH             Branch/tag to check out. MUST exist in KERNEL_REPO
+#                             and should match the target's kernel line so the
+#                             built kernel boots. Default is an AL2023 6.12 tag.
+#   KERNEL_LOCALVERSION       LOCALVERSION suffix for the build (default -inttest).
+#                             Phase 2 asserts the booted `uname -r` carries it.
+#   JOBS                      Parallel build jobs (default: chosen remotely by
+#                             build_kernel.sh -- the box's nproc -- when unset).
+#   NO_PERF=true              Pass --no-perf (skip building perf; skips that check).
+#
+set -uo pipefail
+
+# --------------------------------------------------------------------------
+# Locate the script under test.
+# --------------------------------------------------------------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${HERE}/../.." && pwd)"
+SUT="${ROOT}/scripts/build_kernel.sh"                 # script under test
+[ -f "${SUT}" ] || { echo "cannot find ${SUT}" >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+# Tunables (see header).
+KERNEL_REPO="${KERNEL_REPO:-https://github.com/amazonlinux/linux.git}"
+KERNEL_BRANCH="${KERNEL_BRANCH:-kernel6.12-6.12.68-92.122.amzn2023}"
+KERNEL_LOCALVERSION="${KERNEL_LOCALVERSION:--inttest}"
+JOBS="${JOBS:-}"
+NO_PERF="${NO_PERF:-false}"
+
+# --------------------------------------------------------------------------
+# Options.
+# --------------------------------------------------------------------------
+CONFIRM="${CONFIRM:-}"
+CONFIG_ONLY="false"
+REMOTE=""
+KEY_FILE=""
+EXTRA_SSH="${SSH_OPTIONS:-}"     # honour SSH_OPTIONS env, like build_kernel does
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -c|--connect)  REMOTE="${2:-}"; shift ;;
+        -i|--key)      KEY_FILE="${2:-}"; shift ;;
+        --ssh-options) EXTRA_SSH="${2:-}"; shift ;;
+        --config-only) CONFIG_ONLY="true" ;;
+        --yes)         CONFIRM="yes" ;;
+        -h|--help) sed -n '2,/^set -uo pipefail$/{/^set -uo pipefail$/d; s/^#\( \|$\)//; p}' "$0"; exit 0 ;;
+        *) echo "unknown argument '$1' (see --help)" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# --------------------------------------------------------------------------
+# Helpers.
+# --------------------------------------------------------------------------
+RED=$'\033[31m'; GRN=$'\033[32m'; YEL=$'\033[33m'; CYN=$'\033[36m'; RST=$'\033[0m'
+info() { printf '%s[intg]%s %s\n' "${CYN}" "${RST}" "$*"; }
+warn() { printf '%s[intg]%s %s\n' "${YEL}" "${RST}" "$*"; }
+err()  { printf '%s[intg]%s %s\n' "${RED}" "${RST}" "$*" >&2; }
+
+command -v ssh >/dev/null 2>&1 || { err "ssh not found in PATH (required)"; exit 2; }
+
+TESTS=0 PASS=0 FAIL=0
+check() {         # check <label> <expected> <actual>
+    TESTS=$((TESTS+1))
+    if [ "$2" = "$3" ]; then
+        PASS=$((PASS+1)); printf '    %s✓%s %s\n' "${GRN}" "${RST}" "$1"
+    else
+        FAIL=$((FAIL+1)); printf '    %s✗%s %s  (expected [%s] got [%s])\n' "${RED}" "${RST}" "$1" "$2" "$3"
+    fi
+}
+check_yes() {     # check_yes <label> <actual: yes|no>
+    check "$1" "yes" "$2"
+}
+fail_now() {      # fail_now <label> -- record a failed assertion with a message
+    TESTS=$((TESTS+1)); FAIL=$((FAIL+1)); printf '    %s✗%s %s\n' "${RED}" "${RST}" "$1"
+}
+
+# --------------------------------------------------------------------------
+# Validate inputs.
+# --------------------------------------------------------------------------
+[ -n "${REMOTE}" ] || { err "no SSH target; pass -c USER@HOST (see --help)"; exit 2; }
+case "${REMOTE}" in *@*) : ;; *) warn "target '${REMOTE}' has no user@; ssh will use your default user" ;; esac
+if [ -n "${KEY_FILE}" ]; then
+    [ -f "${KEY_FILE}" ] || { err "key file not found: ${KEY_FILE}"; exit 2; }
+fi
+
+# Build the SSH option string used BOTH for our own verification ssh and, via
+# SSH_OPTIONS, for build_kernel's remote calls -- so both sides authenticate the
+# same way. -i (if given) first, then the caller extras, then non-interactive
+# defaults (no host-key prompts / known_hosts churn against throw-away boxes).
+SSH_OPTS=""
+[ -n "${KEY_FILE}" ] && SSH_OPTS="-i ${KEY_FILE}"
+[ -n "${EXTRA_SSH}" ] && SSH_OPTS="${SSH_OPTS:+${SSH_OPTS} }${EXTRA_SSH}"
+SSH_OPTS="${SSH_OPTS:+${SSH_OPTS} }-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+
+rssh() { command ssh ${SSH_OPTS} -o ConnectTimeout=10 "${REMOTE}" "$@"; }
+
+# --------------------------------------------------------------------------
+# Confirmation gate + target banner.
+# --------------------------------------------------------------------------
+PHASES="Phase 1 (config-only) + Phase 2 (full build + reboot)"
+[ "${CONFIG_ONLY}" = "true" ] && PHASES="Phase 1 (config-only) ONLY"
+
+cat <<BANNER
+
+${YEL}============== REAL build_kernel integration test ==============${RST}
+  Target  : ${REMOTE}
+  Key     : ${KEY_FILE:-(none / from agent or default)}
+  Kernel  : ${KERNEL_REPO} @ ${KERNEL_BRANCH}  (LOCALVERSION=${KERNEL_LOCALVERSION})
+  Running : ${PHASES}
+  This is DESTRUCTIVE to the target: Phase 2 builds+installs a kernel, makes it
+  the default boot entry, and REBOOTS the machine (can take tens of minutes).
+${YEL}================================================================${RST}
+
+BANNER
+
+if [ "${CONFIRM}" != "yes" ]; then
+    err "Refusing to run without confirmation. Re-run with --yes (or CONFIRM=yes) once you've checked the target above."
+    exit 3
+fi
+
+# --------------------------------------------------------------------------
+# SSH reachability + baseline.
+# --------------------------------------------------------------------------
+wait_for_ssh() {         # wait until sshd answers (boot / reboot); ~5 min cap
+    local n=0
+    info "Waiting for SSH on ${REMOTE} ..."
+    while ! rssh true >/dev/null 2>&1; do
+        n=$((n+1))
+        if [ "${n}" -gt 60 ]; then err "SSH never came up on ${REMOTE}"; return 1; fi
+        sleep 5
+    done
+    info "SSH is up."
+    return 0
+}
+
+if ! wait_for_ssh; then
+    fail_now "target reachable over SSH"
+    printf '\n%s%d CHECK(S) FAILED%s\n' "${RED}" "$((FAIL))" "${RST}"
+    exit 1
+fi
+check_yes "target reachable over SSH" "yes"
+
+# Baseline kernel (what the box currently boots) -- Phase 2 must change this.
+BASELINE_KVER="$(rssh 'uname -r' 2>/dev/null | tr -d '[:space:]' || true)"
+info "Baseline kernel on the box: ${BASELINE_KVER:-<unknown>}"
+
+# build_kernel.sh's default remote KERNEL_DIR is ~/linux-next, evaluated as the
+# SSH user's home ON THE REMOTE. Query it rather than guessing /home/<user>.
+REMOTE_HOME="$(rssh 'printf %s "$HOME"' 2>/dev/null | tr -d '[:space:]' || true)"
+[ -n "${REMOTE_HOME}" ] || REMOTE_HOME="/home/${REMOTE%@*}"
+REMOTE_KDIR="${REMOTE_HOME}/linux-next"
+info "Remote kernel tree will be: ${REMOTE_KDIR}"
+
+# --------------------------------------------------------------------------
+# A pure-addition patch (creates a new file) applies cleanly to ANY kernel tree
+# with `git apply`, so we can prove the patch upload+apply path without needing
+# a context-matching diff against an unknown source tree.
+# --------------------------------------------------------------------------
+MARKER="bk_inttest_marker_$$.txt"
+PATCH="${WORK}/marker.patch"
+cat > "${PATCH}" <<PATCHEOF
+--- /dev/null
++++ b/${MARKER}
+@@ -0,0 +1,1 @@
++build_kernel integration test marker
+PATCHEOF
+
+# --------------------------------------------------------------------------
+# Phase 1: remote --config-only. Cheap-ish gate on the whole remote pipeline.
+# --------------------------------------------------------------------------
+printf '\n%s== Phase 1: remote config-only (upload + deps + clone + patch + config) ==%s\n' "${CYN}" "${RST}"
+info "Running build_kernel.sh -c ${REMOTE} --config-only ..."
+if SSH_OPTIONS="${SSH_OPTS}" bash "${SUT}" \
+        -c "${REMOTE}" \
+        -r "${KERNEL_REPO}" -b "${KERNEL_BRANCH}" \
+        -p "${PATCH}" \
+        --config-only \
+        >"${WORK}/phase1.log" 2>&1; then
+    check_yes "config-only remote run exits 0" "yes"
+else
+    fail_now "config-only remote run exits 0"
+    err "phase 1 output (tail):"; tail -n 25 "${WORK}/phase1.log" | sed 's/^/      /' >&2
+fi
+
+# The remote log build_kernel saves must exist.
+check_yes "remote build log saved (~/build_kernel_*.log)" \
+    "$(rssh 'ls -1 ~/build_kernel_*.log >/dev/null 2>&1 && echo yes || echo no')"
+
+# The patch we uploaded must have been applied into the remote tree.
+check_yes "uploaded patch applied on remote (marker file in tree)" \
+    "$(rssh "test -f '${REMOTE_KDIR}/${MARKER}' && echo yes || echo no")"
+
+# The EC2/ENA config tweaks must be in the generated .config on the remote.
+# Assert CONFIG_NET_VENDOR_AMAZON=y: it is ALWAYS appended (unlike
+# CONFIG_ENA_ETHERNET=m, which the script deliberately omits on the Amazon Linux
+# tree, where a downstream ENA driver already builds ena.ko).
+check_yes "EC2/ENA tweak present in remote .config (CONFIG_NET_VENDOR_AMAZON=y)" \
+    "$(rssh "grep -q '^CONFIG_NET_VENDOR_AMAZON=y' '${REMOTE_KDIR}/.config' && echo yes || echo no")"
+
+# --------------------------------------------------------------------------
+# Phase 2: full build + reboot into the new kernel. The expensive real test.
+# --------------------------------------------------------------------------
+if [ "${CONFIG_ONLY}" = "true" ]; then
+    warn "--config-only set: skipping the full build + reboot phase."
+else
+    printf '\n%s== Phase 2: full remote build + reboot (this can take a while) ==%s\n' "${CYN}" "${RST}"
+    PERF_FLAG=(); [ "${NO_PERF}" = "true" ] && PERF_FLAG=(--no-perf)
+    JOBS_FLAG=(); [ -n "${JOBS}" ] && JOBS_FLAG=(-j "${JOBS}")
+    info "Running build_kernel.sh -c ${REMOTE} --yes (build + install + reboot) ..."
+    if SSH_OPTIONS="${SSH_OPTS}" bash "${SUT}" \
+            -c "${REMOTE}" \
+            -r "${KERNEL_REPO}" -b "${KERNEL_BRANCH}" \
+            -l "${KERNEL_LOCALVERSION}" \
+            "${JOBS_FLAG[@]}" "${PERF_FLAG[@]}" \
+            --yes \
+            >"${WORK}/phase2.log" 2>&1; then
+        check_yes "full remote build + reboot exits 0" "yes"
+    else
+        fail_now "full remote build + reboot exits 0"
+        err "phase 2 output (tail):"; tail -n 30 "${WORK}/phase2.log" | sed 's/^/      /' >&2
+    fi
+
+    # build_kernel --yes already waited for the box to come back; re-confirm SSH
+    # ourselves, then INDEPENDENTLY verify the running kernel.
+    if wait_for_ssh; then
+        NEW_KVER="$(rssh 'uname -r' 2>/dev/null | tr -d '[:space:]' || true)"
+        info "Kernel after reboot: ${NEW_KVER:-<unknown>}"
+        # It must have changed from what the box booted before ...
+        check_yes "running kernel changed after reboot" \
+            "$( [ -n "${NEW_KVER}" ] && [ "${NEW_KVER}" != "${BASELINE_KVER}" ] && echo yes || echo no )"
+        # ... and it must carry the LOCALVERSION suffix we asked build_kernel for.
+        check_yes "running kernel carries LOCALVERSION '${KERNEL_LOCALVERSION}'" \
+            "$( case "${NEW_KVER}" in *"${KERNEL_LOCALVERSION}"*) echo yes ;; *) echo no ;; esac )"
+
+        # perf built + installed on the box (unless we asked to skip it).
+        if [ "${NO_PERF}" != "true" ]; then
+            check_yes "perf installed on remote (/usr/local/bin/perf runs)" \
+                "$(rssh '/usr/local/bin/perf --version >/dev/null 2>&1 && echo yes || echo no')"
+        fi
+    else
+        fail_now "target reachable over SSH after reboot"
+    fi
+fi
+
+# --------------------------------------------------------------------------
+# Summary.
+# --------------------------------------------------------------------------
+printf '\n%s==================== Results ====================%s\n' "${CYN}" "${RST}"
+printf '  assertions: %d   passed: %s%d%s   failed: %s%d%s\n' \
+    "${TESTS}" "${GRN}" "${PASS}" "${RST}" "${RED}" "${FAIL}" "${RST}"
+if [ "${FAIL}" -eq 0 ]; then
+    printf '  %sALL CHECKS PASSED%s\n' "${GRN}" "${RST}"
+    exit 0
+else
+    printf '  %s%d CHECK(S) FAILED%s\n' "${RED}" "${FAIL}" "${RST}"
+    exit 1
+fi

--- a/tests/unit/helpers/fake_kernel.bash
+++ b/tests/unit/helpers/fake_kernel.bash
@@ -1,0 +1,275 @@
+# fake_kernel.bash - shared Bats helper: hermetic fakes + runner for
+# scripts/build_kernel.sh.
+#
+# Strategy (same spirit as fake_aws.bash): NO real kernel is ever built and
+# NOTHING is installed or rebooted. Every external command build_kernel.sh
+# shells out to (git, make, sudo, dracut, grubby, update-grub,
+# update-initramfs, reboot, dnf/apt-get, ssh, scp, ...) is shadowed by a fake
+# placed first on PATH. Each fake logs its full argv so a test can assert on the
+# exact command sequence. The script runs under `env -i` for full isolation,
+# with a curated "toolbox" of the real coreutils it needs as the only other
+# thing on PATH -- so package-manager detection (dnf vs apt) is deterministic
+# regardless of the host distro.
+#
+# Provides:
+#   make_fake_kernel_env  - build the fake bin + toolbox (call from setup_file)
+#   fake_kernel_reset     - per-test capture/scratch files (call from setup)
+#   set_pkg dnf|apt       - choose which package manager the script detects
+#   run_script ...        - run non-interactively (piped stdin)
+#   run_tty ...           - run on a real PTY (exercises the reboot prompt)
+#   freshdir N            - a fresh per-test --dir target
+#
+# run_script / run_tty set globals: RC, OUTPUT (combined), OPS (build oplog),
+# SSHLOG (ssh/scp calls), REMOTECMD (extracted remote command).
+#
+# Usage in a .bats file:
+#   load '../helpers/fake_kernel'
+#   setup_file() { make_fake_kernel_env; }
+#   setup()      { ...; fake_kernel_reset; }
+
+# uname -r is faked to a fixed string so the config-seed path is deterministic.
+FAKE_UNAME_R="6.6.0-fake"
+
+make_fake_kernel_env() {
+    export FAKEBIN="${BATS_FILE_TMPDIR}/bin"
+    export TOOLBOX="${BATS_FILE_TMPDIR}/toolbox"
+    export BOOT="${BATS_FILE_TMPDIR}/boot"
+    mkdir -p "${FAKEBIN}" "${TOOLBOX}" "${BOOT}"
+
+    # Seed a running-kernel config so step 3 (cp $BOOT/config-$(uname -r)) works.
+    printf 'CONFIG_LOCALVERSION=""\n' > "${BOOT}/config-${FAKE_UNAME_R}"
+
+    # --- git: clone creates a tree with scripts/config + tools/perf; rev-parse
+    # prints a fixed short commit; checkout/fetch/apply are recorded no-ops
+    # (apply --check fails when FAKE_PATCH_BAD=1 to exercise the reject path).
+    cat > "${FAKEBIN}/git" <<'FAKE'
+#!/usr/bin/env bash
+echo "git $*" >> "${OPLOG}"
+sub="${1:-}"
+# support "git -C <dir> <sub> ..."
+if [ "${sub}" = "-C" ]; then shift 2; sub="${1:-}"; fi
+case "${sub}" in
+    clone)
+        dest="${@: -1}"
+        mkdir -p "${dest}/scripts" "${dest}/tools/perf" "${dest}/.git"
+        # FAKE_DOWNSTREAM_ENA=1 simulates the Amazon Linux tree, which ships a
+        # downstream ENA driver here (in addition to the mainline one). The
+        # script uses this dir's presence to decide whether to force
+        # CONFIG_ENA_ETHERNET=m (skipped when present, to avoid an ena.ko clash).
+        [ "${FAKE_DOWNSTREAM_ENA:-0}" = "1" ] && mkdir -p "${dest}/drivers/amazon/net/ena"
+        # stub perf binary so `cp tools/perf/perf $PERF_DEST` (step 9) succeeds
+        printf '#!/bin/sh\n' > "${dest}/tools/perf/perf"; chmod +x "${dest}/tools/perf/perf"
+        # a minimal `scripts/config` the script calls with --set-str
+        cat > "${dest}/scripts/config" <<'CFG'
+#!/usr/bin/env bash
+echo "scripts/config $*" >> "${OPLOG}"
+CFG
+        chmod +x "${dest}/scripts/config"
+        ;;
+    rev-parse) printf '%s\n' "${FAKE_COMMIT:-abc1234}" ;;
+    apply)
+        # forms: git apply --stat F | git apply --check F | git apply F
+        if [ "${2:-}" = "--check" ] && [ "${FAKE_PATCH_BAD:-0}" = "1" ]; then
+            echo "error: patch does not apply" >&2; exit 1
+        fi
+        ;;
+    checkout)
+        if [ "${FAKE_CHECKOUT_BAD:-0}" = "1" ]; then
+            echo "error: pathspec not found" >&2; exit 1
+        fi
+        ;;
+    fetch) : ;;
+    *) : ;;
+esac
+FAKE
+
+    # --- make: emulate the handful of invocations the script makes.
+    # `kernelrelease` prints a deterministic version and pre-creates the matching
+    # vmlinuz so version-detection's primary branch is taken. Everything else is
+    # a recorded no-op. modules_install/install run via sudo (see below).
+    cat > "${FAKEBIN}/make" <<'FAKE'
+#!/usr/bin/env bash
+echo "make $*" >> "${OPLOG}"
+for a in "$@"; do
+    case "$a" in
+        kernelrelease)
+            printf '%s\n' "${FAKE_KVER:-6.6.0-fake-abc1234}"
+            touch "${BOOT_DIR:-/tmp}/vmlinuz-${FAKE_KVER:-6.6.0-fake-abc1234}" 2>/dev/null || true
+            exit 0 ;;
+    esac
+done
+exit 0
+FAKE
+
+    # --- sudo: strip the leading "sudo" (+ any -E / VAR=val) and exec the rest,
+    # so `sudo make install` hits our fake make, `sudo dracut` our fake dracut,
+    # etc. Record it too.
+    cat > "${FAKEBIN}/sudo" <<'FAKE'
+#!/usr/bin/env bash
+echo "sudo $*" >> "${OPLOG}"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -*) shift ;;
+        *=*) shift ;;
+        *) break ;;
+    esac
+done
+[ $# -gt 0 ] && exec "$@"
+FAKE
+
+    # --- simple recorders. sleep is a no-op so the remote reboot-wait loop is
+    # instant. (dnf/apt-get are created on demand by set_pkg.)
+    for cmd in dracut update-grub update-initramfs reboot sleep; do
+        cat > "${FAKEBIN}/${cmd}" <<FAKE
+#!/usr/bin/env bash
+echo "${cmd} \$*" >> "\${OPLOG}"
+FAKE
+    done
+
+    # --- grubby: --info=<path> fails unless FAKE_GRUB_EXISTS=1 (so we can test
+    # both the add-kernel and the set-default branch); --info=ALL /
+    # --default-kernel succeed quietly.
+    cat > "${FAKEBIN}/grubby" <<'FAKE'
+#!/usr/bin/env bash
+echo "grubby $*" >> "${OPLOG}"
+for a in "$@"; do
+    case "$a" in
+        --info=ALL|--default-kernel) exit 0 ;;
+        --info=*) [ "${FAKE_GRUB_EXISTS:-0}" = "1" ] && exit 0 || exit 1 ;;
+    esac
+done
+exit 0
+FAKE
+
+    # --- ssh/scp: capture calls for the remote-execution tests. ssh also
+    # extracts the remote command from `bash -c '<CMD> 2>&1 | tee <LOG>'` and
+    # answers the post-reboot verification queries (uname/grep).
+    cat > "${FAKEBIN}/ssh" <<'FAKE'
+#!/usr/bin/env bash
+echo "SSH: $*" >> "${SSH_LOG:-/dev/null}"
+if [[ "$*" == *"bash -c"* ]]; then
+    cmd=$(echo "$*" | sed -n "s/.*bash -c '\(.*\) 2>&1 | tee.*/\1/p")
+    echo "REMOTE_CMD: ${cmd}" >> "${SSH_REMOTECMD:-/dev/null}"
+fi
+if [[ "$*" == *"uname -r"* ]]; then
+    printf '%s\n' "${FAKE_REMOTE_KERNEL:-6.12.0-test}"
+elif [[ "$*" == *"uname -v"* ]]; then
+    printf '%s\n' "#1 SMP"
+elif [[ "$*" == *"grep -E"* ]]; then
+    printf '  Commit        : %s\n' "${FAKE_COMMIT:-abc1234}"
+fi
+exit 0
+FAKE
+    cat > "${FAKEBIN}/scp" <<'FAKE'
+#!/usr/bin/env bash
+echo "SCP: $*" >> "${SSH_LOG:-/dev/null}"
+exit 0
+FAKE
+
+    # --- uname -r must be deterministic to match the seeded config file.
+    cat > "${FAKEBIN}/uname" <<FAKE
+#!/usr/bin/env bash
+if [ "\${1:-}" = "-r" ]; then printf '%s\n' "${FAKE_UNAME_R}"; else command uname "\$@"; fi
+FAKE
+
+    chmod +x "${FAKEBIN}"/*
+
+    # --- toolbox: the REAL coreutils the script needs, so the runner PATH is
+    # exactly FAKEBIN:TOOLBOX -- nothing else. This is what makes pkg-manager
+    # detection deterministic (the host's real dnf/apt is never on PATH; only
+    # the fake dropped by set_pkg is). `date` is here for the remote path.
+    # NOTE: git/make/sudo/dracut/grubby/dnf/apt-get/reboot/ssh/scp/update-* are
+    # deliberately EXCLUDED -- they come from FAKEBIN. cp/zcat stay REAL so the
+    # config seed actually copies.
+    local t src
+    for t in bash sh env sed grep egrep cat ls head tail tr sort awk gawk \
+             basename dirname readlink realpath uname nproc mkdir rmdir rm \
+             chmod touch printf cut wc find test true false cp date gzip zcat; do
+        src="$(type -P "$t" 2>/dev/null || true)"
+        [ -n "${src}" ] && ln -sf "${src}" "${TOOLBOX}/$t"
+    done
+    export RUNNER_PATH="${FAKEBIN}:${TOOLBOX}"
+}
+
+# Per-test capture/scratch files live in the test's own tmpdir.
+fake_kernel_reset() {
+    export OPLOG="${BATS_TEST_TMPDIR}/oplog"
+    export SSH_LOG="${BATS_TEST_TMPDIR}/ssh_log"
+    export SSH_REMOTECMD="${BATS_TEST_TMPDIR}/ssh_remotecmd"
+    export SRCROOT="${BATS_TEST_TMPDIR}/src"
+    export PERF="${BATS_TEST_TMPDIR}/perf"
+    : > "${OPLOG}"; : > "${SSH_LOG}"; : > "${SSH_REMOTECMD}"
+    mkdir -p "${SRCROOT}"
+    # Default to dnf; tests that need apt call `set_pkg apt` explicitly.
+    set_pkg dnf
+}
+
+# Choose which package manager the script detects by dropping ONLY that binary
+# on PATH. $1 = "dnf" | "apt".
+set_pkg() {
+    rm -f "${FAKEBIN}/dnf" "${FAKEBIN}/apt-get"
+    if [ "$1" = "dnf" ]; then
+        printf '#!/usr/bin/env bash\necho "dnf $*" >> "${OPLOG}"\n' > "${FAKEBIN}/dnf"
+        chmod +x "${FAKEBIN}/dnf"
+    else
+        printf '#!/usr/bin/env bash\necho "apt-get $*" >> "${OPLOG}"\n' > "${FAKEBIN}/apt-get"
+        chmod +x "${FAKEBIN}/apt-get"
+    fi
+}
+
+# A fresh per-test source dir for --dir.
+freshdir() { echo "${SRCROOT}/k$1"; }
+
+# _invoke <tty:0|1> [FAKE_STDIN=...] [KEY=VAL ...] -- [script args ...]
+# Everything before `--` is env for the target script (except FAKE_STDIN, which
+# is harness-local: what we "type" at the reboot prompt); everything after is
+# argv. With tty=1 a real PTY is allocated via script(1) so the interactive
+# prompt is exercised; TTY_ACTIVE reflects whether that succeeded.
+HAVE_SCRIPT="$(command -v script >/dev/null 2>&1 && echo 1 || echo 0)"
+_invoke() {
+    local tty="$1"; shift
+    : > "${OPLOG}"; : > "${SSH_LOG}"; : > "${SSH_REMOTECMD}"
+    local env_kv=() args=() seen_dd=0 a stdin_answer=""
+    for a in "$@"; do
+        if [ "${seen_dd}" = "0" ] && [ "$a" = "--" ]; then seen_dd=1; continue; fi
+        if [ "${seen_dd}" = "0" ]; then
+            case "$a" in
+                FAKE_STDIN=*) stdin_answer="${a#FAKE_STDIN=}" ;;
+                *)            env_kv+=("$a") ;;
+            esac
+        else
+            args+=("$a")
+        fi
+    done
+    # Write a self-contained runner so env/args survive the `script -c` string.
+    # BASH_ENV / BASH_XTRACEFD / KCOV_BASH_XTRACEFD are forwarded through the
+    # `env -i` barrier so kcov (make coverage) can instrument the script under
+    # test -- without them the wiped environment hides it from the tracer.
+    local runner="${BATS_TEST_TMPDIR}/runner.sh"
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'exec env -i PATH=%q HOME=%q OPLOG=%q BOOT_DIR=%q PERF_DEST=%q SSH_LOG=%q SSH_REMOTECMD=%q \\\n' \
+            "${RUNNER_PATH}" "${HOME}" "${OPLOG}" "${BOOT}" "${PERF}" "${SSH_LOG}" "${SSH_REMOTECMD}"
+        printf '  BASH_ENV=%q BASH_XTRACEFD=%q KCOV_BASH_XTRACEFD=%q \\\n' \
+            "${BASH_ENV:-}" "${BASH_XTRACEFD:-}" "${KCOV_BASH_XTRACEFD:-}"
+        for a in "${env_kv[@]:-}"; do [ -n "$a" ] && printf '  %q \\\n' "$a"; done
+        printf '  bash %q' "${SCRIPT}"
+        for a in "${args[@]:-}"; do printf ' %q' "$a"; done
+        printf '\n'
+    } > "${runner}"
+    chmod +x "${runner}"
+    RC=0; TTY_ACTIVE=0
+    if [ "${tty}" = "1" ] && [ "${HAVE_SCRIPT}" = "1" ]; then
+        TTY_ACTIVE=1
+        OUTPUT="$(printf '%s\n' "${stdin_answer}" | script -qec "${runner}" /dev/null 2>&1 | tr -d '\r')" || RC=$?
+    else
+        OUTPUT="$(printf '%s\n' "${stdin_answer}" | "${runner}" 2>&1)" || RC=$?
+    fi
+    OPS="$(cat "${OPLOG}" 2>/dev/null)"
+    SSHLOG="$(cat "${SSH_LOG}" 2>/dev/null)"
+    REMOTECMD="$(cat "${SSH_REMOTECMD}" 2>/dev/null)"
+}
+
+# run_script: non-interactive (piped stdin). run_tty: real PTY for prompt tests.
+run_script() { _invoke 0 "$@"; }
+run_tty()    { _invoke 1 "$@"; }

--- a/tests/unit/scripts/build_kernel.bats
+++ b/tests/unit/scripts/build_kernel.bats
@@ -1,0 +1,362 @@
+#!/usr/bin/env bats
+#
+# build_kernel.bats - Unit tests for scripts/build_kernel.sh
+#
+# Strategy: NO real kernel is ever built and NOTHING is installed or rebooted.
+# Every external command the script shells out to (git, make, sudo, dracut,
+# grubby, update-grub, update-initramfs, reboot, dnf/apt-get, ssh, scp) is
+# shadowed by a fake first on PATH (tests/unit/helpers/fake_kernel.bash); the
+# script runs under `env -i` for full isolation and each fake logs its argv so
+# we assert on the exact command sequence. The package manager is chosen by
+# which of dnf/apt-get is on PATH, so the SAME harness exercises both the AL2023
+# (dracut+grubby) and Ubuntu (update-grub) paths. This is a port of the two
+# hand-rolled suites tests/scripts/build_kernel.sh (local build) and
+# tests/scripts/build_kernel_remote.sh (remote -c mode) into one bats file.
+#
+# Run:  bats tests/unit/scripts/build_kernel.bats
+#       bats --filter "remote" tests/unit/scripts/build_kernel.bats
+
+setup_file() {
+    export SCRIPT="${BATS_TEST_DIRNAME}/../../../scripts/build_kernel.sh"
+    [ -f "${SCRIPT}" ] || { echo "cannot find ${SCRIPT}" >&2; return 1; }
+    make_fake_kernel_env
+}
+
+setup() {
+    bats_load_library bats-support
+    bats_load_library bats-assert
+    fake_kernel_reset
+}
+
+load '../helpers/fake_kernel'
+
+# Substring assertions on arbitrary strings (OUTPUT / OPS / SSHLOG / REMOTECMD).
+assert_contains() { # <haystack> <needle>
+    case "$1" in *"$2"*) return 0 ;; esac
+    fail "expected to contain [$2]"$'\n'"in: $1"
+}
+assert_not_contains() { # <haystack> <needle>
+    case "$1" in *"$2"*) fail "should NOT contain [$2]"$'\n'"in: $1" ;; esac
+}
+
+# require_tty: skip a PTY-dependent test when no script(1) is available. Gated
+# on HAVE_SCRIPT (known at load time) so it can run *before* the invocation.
+require_tty() { [ "${HAVE_SCRIPT:-0}" = "1" ] || skip "no PTY tool (script(1)) available"; }
+
+# ==========================================================================
+# 0. Static checks
+# ==========================================================================
+
+@test "static: script passes bash -n" {
+    bash -n "${SCRIPT}"
+}
+
+@test "args: --help exits 0 and shows the synopsis" {
+    run_script -- --help
+    assert_equal "$RC" 0
+    assert_contains "$OUTPUT" "build_kernel.sh - Download, patch, build"
+    assert_contains "$OUTPUT" "--patch"
+}
+
+# ==========================================================================
+# 1. Argument validation
+# ==========================================================================
+
+@test "args: unknown argument fails and names it" {
+    run_script -- --bogus
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "Unknown argument"
+}
+
+@test "args: missing patch file fails early" {
+    run_script -- -p "${BATS_TEST_TMPDIR}/does-not-exist.patch" --dir "$(freshdir 1)"
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "Patch file not found"
+}
+
+@test "args: no dnf/apt-get on PATH -> clean die (empty PATCHES[@] safe)" {
+    # Drop both package managers so detection finds neither.
+    rm -f "${FAKEBIN}/dnf" "${FAKEBIN}/apt-get"
+    run_script -- --dir "$(freshdir 0)"
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "No supported package manager"
+}
+
+# ==========================================================================
+# 2. AL2023 (dnf) config-only flow
+# ==========================================================================
+
+@test "dnf: --config-only clones, checks out, seeds config and stops before compile" {
+    run_script -- --skip-deps --config-only --dir "$(freshdir 2)"
+    assert_equal "$RC" 0
+    assert_contains "$OPS" "git clone"
+    assert_contains "$OPS" "checkout -f next-20260707"
+    assert_contains "$OUTPUT" "Seeding .config"
+    assert_contains "$OPS" 'scripts/config --set-str CONFIG_SYSTEM_TRUSTED_KEYS'
+    assert_contains "$OPS" 'scripts/config --set-str CONFIG_SYSTEM_REVOCATION_KEYS'
+    assert_contains "$OPS" "make olddefconfig"
+    assert_not_contains "$OUTPUT" "Compiling kernel"
+    assert_not_contains "$OPS" "dnf install"
+}
+
+@test "dnf: EC2/ENA tweaks land in the generated .config (upstream tree -> ENA forced on)" {
+    # No downstream ENA driver in the tree (upstream / linux-next): the mainline
+    # CONFIG_ENA_ETHERNET=m must be forced on so the box can network.
+    run_script -- --skip-deps --config-only --dir "$(freshdir 2b)"
+    CFG="$(cat "$(freshdir 2b)/.config" 2>/dev/null)"
+    assert_contains "$CFG" "CONFIG_ENA_ETHERNET=m"
+    assert_contains "$CFG" "CONFIG_NET_VENDOR_AMAZON=y"
+    assert_contains "$CFG" "CONFIG_DEBUG_INFO_BTF=n"
+}
+
+@test "dnf: Amazon tree with downstream ENA -> CONFIG_ENA_ETHERNET not forced (avoids ena.ko clash)" {
+    # When the tree already ships a downstream ENA driver (drivers/amazon/net/ena),
+    # forcing the mainline CONFIG_ENA_ETHERNET=m too makes `make modules_check`
+    # abort on a duplicate ena.ko. The script must NOT append it in that case, but
+    # the other tweaks still apply.
+    run_script FAKE_DOWNSTREAM_ENA=1 -- --skip-deps --config-only --dir "$(freshdir 2c)"
+    assert_equal "$RC" 0
+    CFG="$(cat "$(freshdir 2c)/.config" 2>/dev/null)"
+    assert_not_contains "$CFG" "CONFIG_ENA_ETHERNET=m"
+    assert_contains "$CFG" "CONFIG_NET_VENDOR_AMAZON=y"
+    assert_contains "$CFG" "CONFIG_DEBUG_INFO_BTF=n"
+    assert_contains "$OUTPUT" "Downstream Amazon ENA driver present"
+}
+
+# ==========================================================================
+# 3. AL2023 (dnf) full build + install + grub
+# ==========================================================================
+
+@test "dnf: full flow compiles, installs modules+kernel, builds perf, wires grub" {
+    run_tty FAKE_STDIN="n" -- --skip-deps --dir "$(freshdir 3)"
+    assert_equal "$RC" 0
+    assert_contains "$OUTPUT" "Compiling kernel"
+    assert_contains "$OPS" "make INSTALL_MOD_STRIP=1 modules_install"
+    assert_contains "$OPS" "make install"
+    assert_contains "$OUTPUT" "Building + installing perf"
+    assert_contains "$OPS" "dracut --force"
+    assert_contains "$OPS" "grubby --add-kernel"
+    assert_contains "$OPS" "--make-default"
+    assert_contains "$OPS" "grubby --info=ALL"
+}
+
+@test "dnf: reboot prompt shown and declining with 'n' skips reboot" {
+    require_tty
+    run_tty FAKE_STDIN="n" -- --skip-deps --dir "$(freshdir 3p)"
+    assert_contains "$OUTPUT" "Reboot now into"
+    assert_contains "$OUTPUT" "Reboot skipped"
+    assert_not_contains "$OPS" "sudo reboot"
+}
+
+@test "safety: non-interactive stdin never auto-reboots" {
+    run_script -- --skip-deps --dir "$(freshdir 3n)"
+    assert_equal "$RC" 0
+    assert_contains "$OUTPUT" "Non-interactive shell"
+    assert_not_contains "$OPS" "sudo reboot"
+}
+
+@test "dnf: existing grub entry -> set-default, not add-kernel" {
+    run_script FAKE_GRUB_EXISTS=1 -- --skip-deps --dir "$(freshdir 3b)"
+    assert_contains "$OPS" "grubby --set-default"
+    assert_not_contains "$OPS" "grubby --add-kernel"
+}
+
+# ==========================================================================
+# 4. Reboot modes
+# ==========================================================================
+
+@test "reboot: --yes reboots without a prompt" {
+    run_script -- --skip-deps --yes --dir "$(freshdir 4a)"
+    assert_equal "$RC" 0
+    assert_contains "$OPS" "sudo reboot"
+    assert_not_contains "$OUTPUT" "Reboot now into"
+}
+
+@test "reboot: --no-reboot prints the instruction and does not reboot" {
+    run_script -- --skip-deps --no-reboot --dir "$(freshdir 4b)"
+    assert_contains "$OUTPUT" "Not rebooting"
+    assert_not_contains "$OPS" "sudo reboot"
+}
+
+@test "reboot: prompt + Enter (default yes) reboots" {
+    require_tty
+    run_tty FAKE_STDIN="" -- --skip-deps --dir "$(freshdir 4c)"
+    assert_contains "$OPS" "sudo reboot"
+}
+
+@test "reboot: prompt + 'y' reboots" {
+    require_tty
+    run_tty FAKE_STDIN="y" -- --skip-deps --dir "$(freshdir 4d)"
+    assert_contains "$OPS" "sudo reboot"
+}
+
+# ==========================================================================
+# 5. Patches (repeatable -p, applied in order)
+# ==========================================================================
+
+@test "patches: two patches applied in the given order (P1 before P2)" {
+    P1="${BATS_TEST_TMPDIR}/fix1.patch"; P2="${BATS_TEST_TMPDIR}/fix2.patch"
+    : > "$P1"; : > "$P2"
+    run_script -- --skip-deps --config-only -p "$P1" -p "$P2" --dir "$(freshdir 5)"
+    assert_equal "$RC" 0
+    assert_contains "$OPS" "git apply --stat ${P1}"
+    assert_contains "$OPS" "git apply --check ${P1}"
+    assert_contains "$OPS" "git apply ${P1}"
+    assert_contains "$OPS" "git apply ${P2}"
+    ORDER_OK=$(awk -v p1="git apply ${P1}" -v p2="git apply ${P2}" '
+        $0==p1 && !seen2 {seen1=NR} $0==p2 {seen2=NR}
+        END{ print (seen1 && seen2 && seen1<seen2) ? "yes" : "no" }' "${OPLOG}")
+    assert_equal "$ORDER_OK" "yes"
+}
+
+@test "patches: an unappliable patch (--check fails) aborts with a clear message" {
+    P1="${BATS_TEST_TMPDIR}/fix1.patch"; : > "$P1"
+    run_script FAKE_PATCH_BAD=1 -- --skip-deps --config-only -p "$P1" --dir "$(freshdir 5b)"
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "does not apply cleanly"
+}
+
+# ==========================================================================
+# 6. Ubuntu (apt) flow
+# ==========================================================================
+
+@test "apt: uses update-grub, not dracut/grubby, and warns about newest-by-default" {
+    set_pkg apt
+    run_script -- --skip-deps --dir "$(freshdir 6)"
+    assert_equal "$RC" 0
+    assert_contains "$OPS" "update-grub"
+    assert_not_contains "$OPS" "dracut --force"
+    assert_not_contains "$OPS" "grubby --add-kernel"
+    assert_contains "$OUTPUT" "boots the newest kernel"
+}
+
+# ==========================================================================
+# 7. Flag plumbing (repo/branch/jobs/localversion/no-perf)
+# ==========================================================================
+
+@test "flags: custom --repo/--branch/--localversion threaded through" {
+    run_script -- --skip-deps --config-only \
+        --repo https://example.com/linux.git --branch mytag \
+        --dir "$(freshdir 7)" --localversion -custom
+    assert_contains "$OPS" "git clone https://example.com/linux.git"
+    assert_contains "$OPS" "checkout -f mytag"
+    assert_contains "$OUTPUT" "LOCALVERSION: -custom"
+}
+
+@test "flags: custom --jobs threaded into make" {
+    run_script -- --skip-deps --jobs 3 --dir "$(freshdir 7b)"
+    assert_contains "$OPS" "make -j 3"
+}
+
+@test "flags: --no-perf skips the perf build" {
+    run_script -- --skip-deps --no-perf --dir "$(freshdir 7d)"
+    assert_not_contains "$OUTPUT" "Building + installing perf"
+    assert_contains "$OUTPUT" "Skipping perf build"
+}
+
+@test "flags: perf lands at PERF_DEST on a normal run" {
+    run_script -- --skip-deps --dir "$(freshdir 7e)"
+    assert_contains "$OPS" "cp ${SRCROOT}/k7e/tools/perf/perf ${PERF}"
+}
+
+# ==========================================================================
+# 8. Dependency install (recorders assert the step fires + names a package)
+# ==========================================================================
+
+@test "deps: dnf install invoked when deps not skipped, lists key packages" {
+    run_script -- --config-only --dir "$(freshdir 8a)"
+    assert_contains "$OPS" "dnf install -y"
+    assert_contains "$OPS" "flex"
+    assert_contains "$OPS" "grubby"
+}
+
+@test "deps: apt-get update+install invoked, lists key packages" {
+    set_pkg apt
+    run_script -- --config-only --dir "$(freshdir 8b)"
+    assert_contains "$OPS" "apt-get update"
+    assert_contains "$OPS" "apt-get install -y"
+    assert_contains "$OPS" "build-essential"
+    assert_contains "$OPS" "initramfs-tools"
+}
+
+# ==========================================================================
+# 9. Existing-tree reuse + non-git dir rejection
+# ==========================================================================
+
+@test "tree: existing git tree -> fetch, not clone" {
+    REUSE="$(freshdir 9)"; mkdir -p "${REUSE}/.git"
+    run_script -- --skip-deps --config-only --dir "${REUSE}"
+    assert_contains "$OPS" "fetch"
+    assert_not_contains "$OPS" "git clone"
+}
+
+@test "tree: non-git existing dir rejected" {
+    NOTGIT="${BATS_TEST_TMPDIR}/notgit"; mkdir -p "${NOTGIT}"; : > "${NOTGIT}/somefile"
+    run_script -- --skip-deps --config-only --dir "${NOTGIT}"
+    assert_equal "$RC" 1
+    assert_contains "$OUTPUT" "not a git repo"
+}
+
+# ==========================================================================
+# 10. Remote execution mode (-c USER@HOST): mocks ssh/scp, asserts on the
+#     uploaded files and the constructed remote command.
+# ==========================================================================
+
+@test "remote: basic run uploads patch + script and runs bash -c remotely" {
+    P="${BATS_TEST_TMPDIR}/test.patch"; echo "dummy patch" > "$P"
+    run_script -- -c ec2-user@192.168.1.1 -p "$P" --yes
+    assert_contains "$SSHLOG" "mkdir -p /tmp/build_kernel_patches"
+    assert_contains "$SSHLOG" "test.patch ec2-user@192.168.1.1:/tmp/build_kernel_patches"
+    assert_contains "$SSHLOG" "build_kernel.sh ec2-user@192.168.1.1:/tmp/build_kernel_remote"
+    assert_contains "$SSHLOG" "bash -c"
+}
+
+@test "remote: multiple patches all uploaded" {
+    P1="${BATS_TEST_TMPDIR}/fix1.patch"; P2="${BATS_TEST_TMPDIR}/fix2.patch"
+    echo "patch 1" > "$P1"; echo "patch 2" > "$P2"
+    run_script -- -c user@host -p "$P1" -p "$P2"
+    assert_contains "$SSHLOG" "fix1.patch"
+    assert_contains "$SSHLOG" "fix2.patch"
+    N="$(grep -c "\.patch user@host:/tmp/build_kernel_patches" "${SSH_LOG}")"
+    assert_equal "$N" 2
+}
+
+@test "remote: all flags passed through to the remote command" {
+    P="${BATS_TEST_TMPDIR}/test.patch"; echo "patch" > "$P"
+    run_script -- -c user@host -p "$P" \
+        -r https://example.com/linux.git -b test-branch --no-perf --skip-deps --yes
+    assert_contains "$REMOTECMD" "-p /tmp/build_kernel_patches/test.patch"
+    assert_contains "$REMOTECMD" "-r https://example.com/linux.git"
+    assert_contains "$REMOTECMD" "-b test-branch"
+    assert_contains "$REMOTECMD" "--no-perf"
+    assert_contains "$REMOTECMD" "--skip-deps"
+    assert_contains "$REMOTECMD" "--yes"
+}
+
+@test "remote: SSH_OPTIONS are honored on the ssh/scp calls" {
+    P="${BATS_TEST_TMPDIR}/test.patch"; echo "patch" > "$P"
+    run_script SSH_OPTIONS="-i /path/to/key.pem -o StrictHostKeyChecking=no" \
+        -- -c user@host -p "$P"
+    assert_contains "$SSHLOG" "SSH: -i /path/to/key.pem -o StrictHostKeyChecking=no"
+}
+
+@test "remote: log file carries a YYYYMMDD_HHMMSS timestamp" {
+    P="${BATS_TEST_TMPDIR}/test.patch"; echo "patch" > "$P"
+    run_script -- -c user@host -p "$P"
+    run grep -q "tee.*build_kernel_[0-9]\{8\}_[0-9]\{6\}\.log" "${SSH_LOG}"
+    assert_equal "$status" 0
+}
+
+@test "remote: no patches -> uploads none but still uploads+runs the script" {
+    run_script -- -c user@host --yes
+    assert_not_contains "$SSHLOG" ".patch user@host"
+    assert_contains "$SSHLOG" "build_kernel.sh user@host:/tmp/build_kernel_remote"
+    assert_contains "$SSHLOG" "bash -c"
+}
+
+@test "remote: --yes triggers post-reboot verification" {
+    run_script -- -c user@host --yes
+    assert_contains "$OUTPUT" "Waiting for remote host to reboot"
+    assert_contains "$OUTPUT" "Remote Kernel Verification"
+    assert_contains "$OUTPUT" "New kernel"
+}


### PR DESCRIPTION
Adds a flag-driven bash script to download, patch, build and install a Linux kernel locally or on a remote host via SSH, with matching bats unit tests (34 cases, all pass), shared fake helpers, and an integration test for the remote-execution path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
